### PR TITLE
Feature/add support for querying active correlations

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -13,6 +13,7 @@ function registerInContainer(container) {
   container
     .register('ManagementApiService', ManagementApiService)
     .dependencies(
+      'CorrelationService',
       'EventAggregator',
       'ExecutionContextFacadeFactory',
       'FlowNodeInstanceService',

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.1.0",
     "@essential-projects/event_aggregator_contracts": "^3.0.0",
-    "@process-engine/management_api_contracts": "feature~add_support_for_querying_active_correlations",
-    "@process-engine/process_engine_contracts": "feature~add_support_for_querying_active_correlations",
+    "@process-engine/management_api_contracts": "^0.5.0",
+    "@process-engine/process_engine_contracts": "^16.0.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "service implementation for the process-engine.io Management APIs",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.1.0",
     "@essential-projects/event_aggregator_contracts": "^3.0.0",
-    "@process-engine/management_api_contracts": "^0.4.0",
-    "@process-engine/process_engine_contracts": "^15.0.0",
+    "@process-engine/management_api_contracts": "feature~add_support_for_querying_active_correlations",
+    "@process-engine/process_engine_contracts": "feature~add_support_for_querying_active_correlations",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/src/converters/correlation_converter.ts
+++ b/src/converters/correlation_converter.ts
@@ -1,0 +1,10 @@
+import {Correlation} from '@process-engine/management_api_contracts';
+import {Runtime} from '@process-engine/process_engine_contracts';
+
+export function managementApiCorrelationConverter(runtimeCorrelation: Runtime.Types.Correlation): Correlation {
+  const managementApiCorrelation: Correlation = new Correlation();
+  managementApiCorrelation.id = runtimeCorrelation.id;
+  managementApiCorrelation.processModelId = runtimeCorrelation.processModelId;
+
+  return managementApiCorrelation;
+}

--- a/src/converters/index.ts
+++ b/src/converters/index.ts
@@ -1,3 +1,4 @@
+export * from './correlation_converter';
 export * from './event_converter';
 export * from './process_model_converter';
 export * from './user_task_converter';

--- a/src/management_api_service.ts
+++ b/src/management_api_service.ts
@@ -104,10 +104,7 @@ export class ManagementApiService implements IManagementApiService {
     const executionContextFacade: IExecutionContextFacade = await this._createExecutionContextFacadeFromManagementContext(context);
     const activeCorrelations: Array<Runtime.Types.Correlation> = await this.correlationService.getAllActiveCorrelations(executionContextFacade);
 
-    const managementApiCorrelations: Array<Correlation> =
-      await BluebirdPromise.map(activeCorrelations, async(runtimeCorrelation: Runtime.Types.Correlation) => {
-        return Converters.managementApiCorrelationConverter(runtimeCorrelation);
-      });
+    const managementApiCorrelations: Array<Correlation> = activeCorrelations.map(Converters.managementApiCorrelationConverter);
 
     return managementApiCorrelations;
   }

--- a/src/management_api_service.ts
+++ b/src/management_api_service.ts
@@ -2,6 +2,7 @@ import * as EssentialProjectErrors from '@essential-projects/errors_ts';
 import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 import {
+  Correlation,
   Event,
   EventList,
   IManagementApiService,
@@ -13,6 +14,7 @@ import {
 } from '@process-engine/management_api_contracts';
 import {
   ExecutionContext,
+  ICorrelationService,
   IExecutionContextFacade,
   IExecutionContextFacadeFactory,
   IFlowNodeInstanceService,
@@ -32,6 +34,7 @@ import * as BluebirdPromise from 'bluebird';
 export class ManagementApiService implements IManagementApiService {
   public config: any = undefined;
 
+  private _correlationService: ICorrelationService;
   private _eventAggregator: IEventAggregator;
   private _executionContextFacadeFactory: IExecutionContextFacadeFactory;
   private _flowNodeInstanceService: IFlowNodeInstanceService;
@@ -42,19 +45,25 @@ export class ManagementApiService implements IManagementApiService {
   private convertProcessModel: Function;
   private convertUserTasks: Function;
 
-  constructor(eventAggregator: IEventAggregator,
+  constructor(correlationService: ICorrelationService,
+              eventAggregator: IEventAggregator,
               executionContextFacadeFactory: IExecutionContextFacadeFactory,
               flowNodeInstanceService: IFlowNodeInstanceService,
               processModelFacadeFactory: IProcessModelFacadeFactory,
               processModelExecutionAdapter: IProcessModelExecutionAdapter,
               processModelService: IProcessModelService) {
 
+    this._correlationService = correlationService;
     this._eventAggregator = eventAggregator;
     this._executionContextFacadeFactory = executionContextFacadeFactory;
     this._flowNodeInstanceService = flowNodeInstanceService;
     this._processModelExecutionAdapter = processModelExecutionAdapter;
     this._processModelFacadeFactory = processModelFacadeFactory;
     this._processModelService = processModelService;
+  }
+
+  private get correlationService(): ICorrelationService {
+    return this._correlationService;
   }
 
   private get eventAggregator(): IEventAggregator {
@@ -87,6 +96,20 @@ export class ManagementApiService implements IManagementApiService {
     this.convertUserTasks = Converters.createUserTaskConverter(this.processModelFacadeFactory, this.processModelService);
 
     return Promise.resolve();
+  }
+
+  // Correlations
+  public async getAllActiveCorrelations(context: ManagementContext): Promise<Array<Correlation>> {
+
+    const executionContextFacade: IExecutionContextFacade = await this._createExecutionContextFacadeFromManagementContext(context);
+    const activeCorrelations: Array<Runtime.Types.Correlation> = await this.correlationService.getAllActiveCorrelations(executionContextFacade);
+
+    const managementApiCorrelations: Array<Correlation> =
+      await BluebirdPromise.map(activeCorrelations, async(runtimeCorrelation: Runtime.Types.Correlation) => {
+        return Converters.managementApiCorrelationConverter(runtimeCorrelation);
+      });
+
+    return managementApiCorrelations;
   }
 
   // Process models


### PR DESCRIPTION
Closes #5 

## What did you change?

Implement a `getAllActiveCorrelations` function, which uses the process engine's `CorrelationService` to retrieve a list of all active correlations.

## How can others test the changes?

Call the `getAllActiveCorrelations` function.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
