### PR TITLE
✨Cyclic TimerStartEvents

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -10,7 +10,6 @@ function registerInContainer(container) {
       'ConsumerApiService',
       'CorrelationService',
       'CronjobService',
-      'DeploymentApiService',
       'EventAggregator',
       'FlowNodeInstanceService',
       'IamService',

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -9,6 +9,7 @@ function registerInContainer(container) {
     .dependencies(
       'ConsumerApiService',
       'CorrelationService',
+      'CronjobService',
       'DeploymentApiService',
       'EventAggregator',
       'FlowNodeInstanceService',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_core",
-  "version": "5.6.0",
+  "version": "5.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,9 +58,9 @@
       }
     },
     "@essential-projects/iam_contracts": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.5.0.tgz",
-      "integrity": "sha512-FpYD5RPuTZnttR/Pr/uJ/GElmWMODd8t8KhcE6duk2QHjqPSwMkitAAtr7/D/vzBx4E7kFXW+p6gLvJ5lBO/kQ=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.6.0.tgz",
+      "integrity": "sha512-BO8rvdz5TAivDqT+I0At55eLe5XORO98rXGIiXl5+p9cXoyh2VMlSJChgAYYZs1DYKBmSTyZCb/Ptk82Hh9S2Q=="
     },
     "@process-engine/consumer_api_contracts": {
       "version": "7.0.1",
@@ -137,9 +137,9 @@
       }
     },
     "@process-engine/process_engine_contracts": {
-      "version": "45.0.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_contracts/-/process_engine_contracts-45.0.0.tgz",
-      "integrity": "sha512-hxiN5CMwYJeXPKQ1yBBsPxiWkguW9Q+Z8GZhBFX/wCmXQ09ArdV8UVRL8gXsP5xO/K5nU6HyVeGdRyzSH5CIMg==",
+      "version": "45.1.0-fdd320ea-b4",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_contracts/-/process_engine_contracts-45.1.0-fdd320ea-b4.tgz",
+      "integrity": "sha512-TPYCo/78KFWxn6oDgxitr31ATAqfLTdCD9O3NqL+AXlx2bCtA5M0bpRjcJpm4Uuk55ljj63+FzH51NstMArtLQ==",
       "requires": {
         "@essential-projects/event_aggregator_contracts": "^4.0.0",
         "@essential-projects/iam_contracts": "^3.4.2"
@@ -1559,9 +1559,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.33",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
-      "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
+      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA=="
     },
     "punycode": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,21 +84,6 @@
         "@essential-projects/iam_contracts": "^3.4.1"
       }
     },
-    "@process-engine/deployment_api_contracts": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@process-engine/deployment_api_contracts/-/deployment_api_contracts-1.0.5.tgz",
-      "integrity": "sha512-9XZ7rVzkDEC1gGxJc+tj1E/RQKZItxgNRgG3rSYFdSeYveKYzq/aqgZvL6apLUXZVTb3BX5eUHINgd68Vqh9Og==",
-      "requires": {
-        "@essential-projects/iam_contracts": "~3.4.0"
-      },
-      "dependencies": {
-        "@essential-projects/iam_contracts": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.4.2.tgz",
-          "integrity": "sha512-XQt9rC545vVCpsyptqZzA2R8dKdKpoyHRnPdOifBH1kP0T9RBvcp/OOnlkrAiweyVRgIVK0RCJa3r4YgTp4nWg=="
-        }
-      }
-    },
     "@process-engine/flow_node_instance.contracts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@process-engine/flow_node_instance.contracts/-/flow_node_instance.contracts-2.0.0.tgz",
@@ -137,18 +122,18 @@
       }
     },
     "@process-engine/process_engine_contracts": {
-      "version": "45.1.0-fdd320ea-b4",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_contracts/-/process_engine_contracts-45.1.0-fdd320ea-b4.tgz",
-      "integrity": "sha512-TPYCo/78KFWxn6oDgxitr31ATAqfLTdCD9O3NqL+AXlx2bCtA5M0bpRjcJpm4Uuk55ljj63+FzH51NstMArtLQ==",
+      "version": "45.1.0-05943492-b13",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_contracts/-/process_engine_contracts-45.1.0-05943492-b13.tgz",
+      "integrity": "sha512-C9i69R8lp9r+DaDMfvbkWzbLnGl3//7OSadyFTlfO8XtZnURq/Liw1f4wVjZ3yrkJasIPmjSKxOEeXA6r5tgvg==",
       "requires": {
         "@essential-projects/event_aggregator_contracts": "^4.0.0",
         "@essential-projects/iam_contracts": "^3.4.2"
       }
     },
     "@process-engine/process_model.contracts": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_model.contracts/-/process_model.contracts-2.4.0.tgz",
-      "integrity": "sha512-cFZsxL1bRsoetOEI0BA+wFhpUO0VKAlRRgQa5qsjZYq/gj6j8FycaG8dDbp8ZMVTkF0l3CPPNtFkx0NVGnIFPQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_model.contracts/-/process_model.contracts-2.5.0.tgz",
+      "integrity": "sha512-GkWKxlXafLSWzBxqA5Q/PSzj0jId02tOgZAeiZZNebhe1MsxnKpTHDMRW3bzRDsJpwjSotose6M2C5PrypxWBQ==",
       "requires": {
         "@essential-projects/iam_contracts": "^3.4.1"
       }
@@ -224,9 +209,9 @@
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
-      "version": "10.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.10.tgz",
-      "integrity": "sha512-V8wj+w2YMNvGuhgl/MA5fmTxgjmVHVoasfIaxMMZJV6Y8Kk+Ydpi1z2whoShDCJ2BuNVoqH/h1hrygnBxkrw/Q=="
+      "version": "10.14.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.12.tgz",
+      "integrity": "sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -313,9 +298,9 @@
       }
     },
     "acorn": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
+      "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -974,9 +959,9 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.4.0.tgz",
-      "integrity": "sha512-4FinE8RfqYnNim20xDwZZE0V2kOs/AuElIjFUbPuegQSaoZM+vUT5FnwSl10KPugH4voTg1bEQlcbCG9ka75TA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz",
+      "integrity": "sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_core",
-  "version": "5.6.0",
+  "version": "5.7.0",
   "description": "service implementation for the process-engine.io Management APIs",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@process-engine/kpi_api_contracts": "^1.3.0",
     "@process-engine/logging_api_contracts": "^1.0.3",
     "@process-engine/management_api_contracts": "^10.0.0",
-    "@process-engine/process_engine_contracts": "^45.0.0",
+    "@process-engine/process_engine_contracts": "feature~cyclic_timer_start_events",
     "@process-engine/process_model.contracts": "^2.3.0",
     "@process-engine/token_history_api_contracts": "^2.0.0",
     "bluebird": "~3.5.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@process-engine/kpi_api_contracts": "^1.3.0",
     "@process-engine/logging_api_contracts": "^1.0.3",
     "@process-engine/management_api_contracts": "^10.0.0",
-    "@process-engine/process_engine_contracts": "feature~cyclic_timer_start_events",
+    "@process-engine/process_engine_contracts": "45.1.0-05943492-b13",
     "@process-engine/process_model.contracts": "^2.3.0",
     "@process-engine/token_history_api_contracts": "^2.0.0",
     "bluebird": "~3.5.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@process-engine/flow_node_instance.contracts": "^2.0.0",
     "@process-engine/consumer_api_contracts": "^7.0.0",
     "@process-engine/correlation.contracts": "^2.0.0",
-    "@process-engine/deployment_api_contracts": "^1.0.0",
     "@process-engine/kpi_api_contracts": "^1.3.0",
     "@process-engine/logging_api_contracts": "^1.0.3",
     "@process-engine/management_api_contracts": "^10.0.0",

--- a/src/management_api_service.ts
+++ b/src/management_api_service.ts
@@ -395,9 +395,9 @@ export class ManagementApiService implements IManagementApi {
   }
 
   public async deleteProcessDefinitionsByProcessModelId(identity: IIdentity, processModelId: string): Promise<void> {
-    await this.cronjobService.remove(processModelId);
+    await this.processModelUseCases.deleteProcessModel(identity, processModelId);
 
-    return this.processModelUseCases.deleteProcessModel(identity, processModelId);
+    await this.cronjobService.remove(processModelId);
   }
 
   // Events

--- a/src/management_api_service.ts
+++ b/src/management_api_service.ts
@@ -20,7 +20,6 @@ export class ManagementApiService implements IManagementApi {
   private readonly consumerApiService: IConsumerApi;
   private readonly correlationService: ICorrelationService;
   private readonly cronjobService: ICronjobService;
-  private readonly deploymentApiService: IDeploymentApi;
   private readonly eventAggregator: IEventAggregator;
   private readonly flowNodeInstanceService: IFlowNodeInstanceService;
   private readonly iamService: IIAMService;
@@ -34,7 +33,6 @@ export class ManagementApiService implements IManagementApi {
     consumerApiService: IConsumerApi,
     correlationService: ICorrelationService,
     cronjobService: ICronjobService,
-    deploymentApiService: IDeploymentApi,
     eventAggregator: IEventAggregator,
     flowNodeInstanceService: IFlowNodeInstanceService,
     iamService: IIAMService,
@@ -47,7 +45,6 @@ export class ManagementApiService implements IManagementApi {
     this.consumerApiService = consumerApiService;
     this.correlationService = correlationService;
     this.cronjobService = cronjobService;
-    this.deploymentApiService = deploymentApiService;
     this.eventAggregator = eventAggregator;
     this.flowNodeInstanceService = flowNodeInstanceService;
     this.iamService = iamService;
@@ -389,14 +386,7 @@ export class ManagementApiService implements IManagementApi {
     name: string,
     payload: DataModels.ProcessModels.UpdateProcessDefinitionsRequestPayload,
   ): Promise<void> {
-
-    const deploymentApiPayload = {
-      name: name,
-      xml: payload.xml,
-      overwriteExisting: payload.overwriteExisting,
-    };
-
-    return this.deploymentApiService.importBpmnFromXml(identity, deploymentApiPayload);
+    return this.processModelUseCases.persistProcessDefinitions(identity, name, payload.xml, payload.overwriteExisting);
   }
 
   public async deleteProcessDefinitionsByProcessModelId(identity: IIdentity, processModelId: string): Promise<void> {

--- a/src/management_api_service.ts
+++ b/src/management_api_service.ts
@@ -9,9 +9,9 @@ import {DataModels as ConsumerApiTypes, IConsumerApi} from '@process-engine/cons
 import {ICorrelationService} from '@process-engine/correlation.contracts';
 import {IDeploymentApi} from '@process-engine/deployment_api_contracts';
 import {DataModels, IManagementApi, Messages} from '@process-engine/management_api_contracts';
-import {IProcessModelFacadeFactory} from '@process-engine/process_engine_contracts';
+import {ICronjobService, IProcessModelFacadeFactory} from '@process-engine/process_engine_contracts';
 import {IProcessModelUseCases} from '@process-engine/process_model.contracts';
-import {FlowNodeInstance, IFlowNodeInstanceService} from '@process-engine/flow_node_instance.contracts';
+import {IFlowNodeInstanceService} from '@process-engine/flow_node_instance.contracts';
 
 import * as Converters from './converters/index';
 
@@ -19,6 +19,7 @@ export class ManagementApiService implements IManagementApi {
 
   private readonly consumerApiService: IConsumerApi;
   private readonly correlationService: ICorrelationService;
+  private readonly cronjobService: ICronjobService;
   private readonly deploymentApiService: IDeploymentApi;
   private readonly eventAggregator: IEventAggregator;
   private readonly flowNodeInstanceService: IFlowNodeInstanceService;
@@ -32,6 +33,7 @@ export class ManagementApiService implements IManagementApi {
   constructor(
     consumerApiService: IConsumerApi,
     correlationService: ICorrelationService,
+    cronjobService: ICronjobService,
     deploymentApiService: IDeploymentApi,
     eventAggregator: IEventAggregator,
     flowNodeInstanceService: IFlowNodeInstanceService,
@@ -44,6 +46,7 @@ export class ManagementApiService implements IManagementApi {
   ) {
     this.consumerApiService = consumerApiService;
     this.correlationService = correlationService;
+    this.cronjobService = cronjobService;
     this.deploymentApiService = deploymentApiService;
     this.eventAggregator = eventAggregator;
     this.flowNodeInstanceService = flowNodeInstanceService;

--- a/src/management_api_service.ts
+++ b/src/management_api_service.ts
@@ -385,10 +385,18 @@ export class ManagementApiService implements IManagementApi {
     name: string,
     payload: DataModels.ProcessModels.UpdateProcessDefinitionsRequestPayload,
   ): Promise<void> {
-    return this.processModelUseCases.persistProcessDefinitions(identity, name, payload.xml, payload.overwriteExisting);
+    await this.processModelUseCases.persistProcessDefinitions(identity, name, payload.xml, payload.overwriteExisting);
+
+    // NOTE: This will only work so lang as ProcessDefinitionName and ProcessModelId remain the same.
+    // As soon as we refactor the ProcessEngine core to allow different names fore each, this will have to be refactored accordingly.
+    const processModel = await this.processModelUseCases.getProcessModelById(identity, name);
+
+    await this.cronjobService.addOrUpdate(processModel);
   }
 
   public async deleteProcessDefinitionsByProcessModelId(identity: IIdentity, processModelId: string): Promise<void> {
+    await this.cronjobService.remove(processModelId);
+
     return this.processModelUseCases.deleteProcessModel(identity, processModelId);
   }
 

--- a/src/management_api_service.ts
+++ b/src/management_api_service.ts
@@ -7,7 +7,6 @@ import {ITokenHistoryApi} from '@process-engine/token_history_api_contracts';
 
 import {DataModels as ConsumerApiTypes, IConsumerApi} from '@process-engine/consumer_api_contracts';
 import {ICorrelationService} from '@process-engine/correlation.contracts';
-import {IDeploymentApi} from '@process-engine/deployment_api_contracts';
 import {DataModels, IManagementApi, Messages} from '@process-engine/management_api_contracts';
 import {ICronjobService, IProcessModelFacadeFactory} from '@process-engine/process_engine_contracts';
 import {IProcessModelUseCases} from '@process-engine/process_model.contracts';


### PR DESCRIPTION
## Changes

1. Use `ProcessModelUseCase` instead of `DeploymentApi` to deploy and undeploy ProcessModels
2. Remove all references and dependencies to `DeploymentApi`
3. Pass newly deployed ProcessModels through `CronjobService`
4. Remove undeployed ProcessModels from `CronjobService`

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/118

PR: #57

## How to test the changes

- Overall deployment mechanism works as before
- When deploying ProcessModels with cyclic TimerStartEvents, new cronjobs will be created for each cyclic TimerStartEvent on that ProcessModel
- When undeploying ProcessModels with cyclic TimerStartEvents, all corresponding cronjobs will be destroyed as well