### PR TITLE
🔥Remove consumer api

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -77,7 +77,7 @@ function registerServices(container){
 
   container
     .register('ManagementApiNotificationService', NotificationService)
-    .dependencies('ManagementApiNotificationAdapter')
+    .dependencies('IamService', 'ManagementApiNotificationAdapter')
     .singleton();
 
   container

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const {
+  NotificationAdapter,
+} = require('./dist/commonjs/index');
+
+const {
   CorrelationService,
   CronjobService,
   EmptyActivityService,

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -15,7 +15,21 @@ const {
   UserTaskService,
 } = require('./dist/commonjs/index');
 
+
 function registerInContainer(container) {
+  registerConvertersAndAdapters(container);
+  registerServices(container);
+}
+
+function registerConvertersAndAdapters(container) {
+
+  container
+    .register('ManagementApiNotificationAdapter', NotificationAdapter)
+    .dependencies('EventAggregator')
+    .singleton();
+}
+
+function registerServices(container){
 
   container
     .register('ManagementApiCorrelationService', CorrelationService)
@@ -59,7 +73,7 @@ function registerInContainer(container) {
 
   container
     .register('ManagementApiNotificationService', NotificationService)
-    .dependencies('ConsumerApiNotificationService')
+    .dependencies('ManagementApiNotificationAdapter')
     .singleton();
 
   container

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const {
+  EmptyActivityConverter,
+  EventConverter,
+  ManualTaskConverter,
   NotificationAdapter,
+  UserTaskConverter,
 } = require('./dist/commonjs/index');
 
 const {
@@ -30,6 +34,26 @@ function registerConvertersAndAdapters(container) {
   container
     .register('ManagementApiNotificationAdapter', NotificationAdapter)
     .dependencies('EventAggregator')
+    .singleton();
+
+  container
+    .register('ManagementApiEmptyActivityConverter', EmptyActivityConverter)
+    .dependencies('CorrelationService', 'ProcessModelFacadeFactory', 'ProcessModelUseCases')
+    .singleton();
+
+  container
+    .register('ManagementApiEventConverter', EventConverter)
+    .dependencies('CorrelationService', 'ProcessModelFacadeFactory', 'ProcessModelUseCases')
+    .singleton();
+
+  container
+    .register('ManagementApiUserTaskConverter', UserTaskConverter)
+    .dependencies('CorrelationService', 'FlowNodeInstanceService', 'ProcessModelFacadeFactory', 'ProcessModelUseCases', 'ProcessTokenFacadeFactory')
+    .singleton();
+
+  container
+    .register('ManagementApiManualTaskConverter', ManualTaskConverter)
+    .dependencies('CorrelationService', 'ProcessModelFacadeFactory', 'ProcessModelUseCases')
     .singleton();
 }
 

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -71,12 +71,22 @@ function registerServices(container){
 
   container
     .register('ManagementApiEmptyActivityService', EmptyActivityService)
-    .dependencies('ConsumerApiEmptyActivityService')
+    .dependencies(
+      'EventAggregator',
+      'FlowNodeInstanceService',
+      'IamService',
+      'ManagementApiNotificationAdapter',
+      'ManagementApiEmptyActivityConverter')
     .singleton();
 
   container
     .register('ManagementApiEventService', EventService)
-    .dependencies('ConsumerApiEventService')
+    .dependencies(
+      'EventAggregator',
+      'FlowNodeInstanceService',
+      'IamService',
+      'ProcessModelUseCases',
+      'ManagementApiEventConverter')
     .singleton();
 
   container
@@ -96,7 +106,12 @@ function registerServices(container){
 
   container
     .register('ManagementApiManualTaskService', ManualTaskService)
-    .dependencies('ConsumerApiManualTaskService')
+    .dependencies(
+      'EventAggregator',
+      'FlowNodeInstanceService',
+      'IamService',
+      'ManagementApiNotificationAdapter',
+      'ManagementApiManualTaskConverter')
     .singleton();
 
   container
@@ -107,12 +122,13 @@ function registerServices(container){
   container
     .register('ManagementApiProcessModelService', ProcessModelService)
     .dependencies(
-      'ConsumerApiProcessModelService',
       'CronjobService',
       'EventAggregator',
+      'ExecuteProcessService',
       'IamService',
       'ProcessModelFacadeFactory',
-      'ProcessModelUseCases')
+      'ProcessModelUseCases',
+      'ManagementApiNotificationAdapter')
     .singleton();
 
   container
@@ -122,7 +138,12 @@ function registerServices(container){
 
   container
     .register('ManagementApiUserTaskService', UserTaskService)
-    .dependencies('ConsumerApiUserTaskService')
+    .dependencies(
+      'EventAggregator',
+      'FlowNodeInstanceService',
+      'IamService',
+      'ManagementApiNotificationAdapter',
+      'ManagementApiUserTaskConverter')
     .singleton();
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,20 +67,6 @@
       "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.6.0.tgz",
       "integrity": "sha512-BO8rvdz5TAivDqT+I0At55eLe5XORO98rXGIiXl5+p9cXoyh2VMlSJChgAYYZs1DYKBmSTyZCb/Ptk82Hh9S2Q=="
     },
-    "@process-engine/consumer_api_contracts": {
-      "version": "8.0.0-dad26234-b24",
-      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_contracts/-/consumer_api_contracts-8.0.0-dad26234-b24.tgz",
-      "integrity": "sha512-yM1yWz6e5KCWpuQLq9yNMeOWhWTNNxbP7vuZonk5aE3bgFC9hEWmp+vAlArhn4XXrn67i6xayfVQJ4AP1XqT6w==",
-      "requires": {
-        "@essential-projects/event_aggregator_contracts": "^4.0.0",
-        "@essential-projects/http_contracts": "^2.3.0",
-        "@essential-projects/iam_contracts": "^3.4.0",
-        "@types/express": "^4.16.0",
-        "@types/node": "^10.12.2",
-        "@types/socket.io": "^2.1.0",
-        "@types/socket.io-client": "^1.4.32"
-      }
-    },
     "@process-engine/correlation.contracts": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@process-engine/correlation.contracts/-/correlation.contracts-2.1.0.tgz",
@@ -254,11 +240,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/socket.io-client": {
-      "version": "1.4.32",
-      "resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.32.tgz",
-      "integrity": "sha512-Vs55Kq8F+OWvy1RLA31rT+cAyemzgm0EWNeax6BWF8H7QiiOYMJIdcwSDdm5LVgfEkoepsWkS+40+WNb7BUMbg=="
     },
     "@types/strip-bom": {
       "version": "3.0.0",
@@ -1374,6 +1355,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,11 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@essential-projects/errors_ts": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/errors_ts/-/errors_ts-1.5.0.tgz",
+      "integrity": "sha512-ePb/JuGX6wVoZ98PhIZMgtrWMj7qIZHy/iuD6tR1udxfMUY1viISEgaPvTCSd9JUPETCsJyhCFnzLUod0kpPBA=="
+    },
     "@essential-projects/eslint-config": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@essential-projects/eslint-config/-/eslint-config-1.0.4.tgz",
@@ -1026,9 +1031,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
+      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
       "dev": true
     },
     "has": {
@@ -1053,10 +1058,13 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-      "dev": true
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
+      "integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -1272,6 +1280,15 @@
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
+      }
     },
     "make-error": {
       "version": "1.3.5",
@@ -1907,9 +1924,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.1.tgz",
-      "integrity": "sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.15.0.tgz",
+      "integrity": "sha512-or184xKZ6fLE1SrDcvsOs3Wkfb1JgizdKs5Fiag3cp/m9k7C7GWd4E7gs3K5LHAePaIP7K62C20ZZI3JQx8iBQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -1988,6 +2005,12 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "yallist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/process-engine/management_api_core#readme",
   "dependencies": {
+    "@essential-projects/errors_ts": "^1.5.0",
     "@process-engine/flow_node_instance.contracts": "^2.0.0",
     "@process-engine/consumer_api_contracts": "8.0.0-dad26234-b24",
     "@process-engine/correlation.contracts": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
     "@process-engine/flow_node_instance.contracts": "^2.0.0",
-    "@process-engine/consumer_api_contracts": "8.0.0-dad26234-b24",
     "@process-engine/correlation.contracts": "^2.0.0",
     "@process-engine/cronjob_history.contracts": "^1.0.0",
     "@process-engine/kpi_api_contracts": "^1.3.0",
@@ -42,7 +41,8 @@
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",
     "clone": "~2.1.2",
-    "moment": "~2.24.0"
+    "moment": "~2.24.0",
+    "node-uuid": "^1.4.8"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,0 +1,1 @@
+export * from './notification_adapter';

--- a/src/adapters/notification_adapter.ts
+++ b/src/adapters/notification_adapter.ts
@@ -1,0 +1,504 @@
+import {EventReceivedCallback, IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
+import {IIdentity} from '@essential-projects/iam_contracts';
+import {Messages} from '@process-engine/management_api_contracts';
+
+import {
+  ActivityFinishedMessage,
+  ActivityReachedMessage,
+  BaseSystemEventMessage,
+  BoundaryEventTriggeredMessage,
+  BpmnType,
+  EndEventReachedMessage,
+  IntermediateCatchEventFinishedMessage,
+  IntermediateCatchEventReachedMessage,
+  IntermediateThrowEventTriggeredMessage,
+  ProcessErrorMessage,
+  ProcessStartedMessage,
+  TerminateEndEventReachedMessage,
+  UserTaskFinishedMessage,
+  UserTaskReachedMessage,
+} from '@process-engine/process_engine_contracts';
+
+export class NotificationAdapter {
+
+  private readonly eventAggregator: IEventAggregator;
+
+  constructor(eventAggregator: IEventAggregator) {
+    this.eventAggregator = eventAggregator;
+  }
+
+  public onActivityReached(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityReachedCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.activityReached;
+
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage<ActivityReachedMessage>(message);
+
+      sanitizedMessage.flowNodeType = message.flowNodeType;
+
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityFinishedCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.activityFinished;
+
+    const sanitationCallback = (message: ActivityFinishedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage<ActivityFinishedMessage>(message);
+
+      sanitizedMessage.flowNodeType = message.flowNodeType;
+
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  // ------------ For backwards compatibility only
+
+  public async onCallActivityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.activityReached;
+
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
+
+      if (message.flowNodeType !== BpmnType.callActivity) {
+        return;
+      }
+
+      const sanitizedMessage = this.sanitizeMessage<ActivityReachedMessage>(message);
+
+      sanitizedMessage.flowNodeType = message.flowNodeType;
+
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public async onCallActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.activityFinished;
+
+    const sanitationCallback = (message: ActivityFinishedMessage): void => {
+
+      if (message.flowNodeType !== BpmnType.callActivity) {
+        return;
+      }
+
+      const sanitizedMessage = this.sanitizeMessage<ActivityFinishedMessage>(message);
+
+      sanitizedMessage.flowNodeType = message.flowNodeType;
+
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  // ------------
+
+  public onEmptyActivityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.emptyActivityReached;
+
+    const sanitationCallback = (message: ActivityFinishedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onEmptyActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnEmptyActivityFinishedCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.emptyActivityFinished;
+
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onEmptyActivityForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.emptyActivityReached;
+
+    const sanitationCallback = (message: ActivityFinishedMessage): void => {
+
+      const identitiesMatch = this.checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
+      if (identitiesMatch) {
+        const sanitizedMessage = this.sanitizeMessage(message);
+        callback(sanitizedMessage);
+      }
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onEmptyActivityForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnEmptyActivityFinishedCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.emptyActivityFinished;
+
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
+
+      const identitiesMatch = this.checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
+      if (identitiesMatch) {
+        const sanitizedMessage = this.sanitizeMessage(message);
+        callback(sanitizedMessage);
+      }
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback, subscribeOnce: boolean): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.userTaskReached;
+
+    const sanitationCallback = (message: UserTaskReachedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback, subscribeOnce: boolean): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.userTaskFinished;
+
+    const sanitationCallback = (message: UserTaskFinishedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage<Messages.SystemEvents.UserTaskFinishedMessage>(message);
+      sanitizedMessage.userTaskResult = message.userTaskResult;
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onUserTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.userTaskReached;
+
+    const sanitationCallback = (message: UserTaskReachedMessage): void => {
+
+      const identitiesMatch = this.checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
+      if (identitiesMatch) {
+        const sanitizedMessage = this.sanitizeMessage(message);
+        callback(sanitizedMessage);
+      }
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onUserTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.userTaskFinished;
+
+    const sanitationCallback = (message: UserTaskFinishedMessage): void => {
+
+      const identitiesMatch = this.checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
+      if (identitiesMatch) {
+        const sanitizedMessage = this.sanitizeMessage<Messages.SystemEvents.UserTaskFinishedMessage>(message);
+        sanitizedMessage.userTaskResult = message.userTaskResult;
+        callback(sanitizedMessage);
+      }
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onManualTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.manualTaskReached;
+
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onManualTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.manualTaskFinished;
+
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onManualTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.manualTaskReached;
+
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
+
+      const identitiesMatch = this.checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
+      if (identitiesMatch) {
+        const sanitizedMessage = this.sanitizeMessage(message);
+        callback(sanitizedMessage);
+      }
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onManualTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.manualTaskFinished;
+
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
+
+      const identitiesMatch = this.checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
+      if (identitiesMatch) {
+        const sanitizedMessage = this.sanitizeMessage(message);
+        callback(sanitizedMessage);
+      }
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onBoundaryEventTriggered(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnBoundaryEventTriggeredCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.boundaryEventTriggered;
+
+    const sanitationCallback = (message: BoundaryEventTriggeredMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onIntermediateThrowEventTriggered(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnIntermediateThrowEventTriggeredCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.intermediateThrowEventTriggered;
+
+    const sanitationCallback = (message: IntermediateThrowEventTriggeredMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onIntermediateCatchEventReached(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnIntermediateCatchEventReachedCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.intermediateCatchEventReached;
+
+    const sanitationCallback = (message: IntermediateCatchEventReachedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onIntermediateCatchEventFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnIntermediateCatchEventFinishedCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.intermediateCatchEventFinished;
+
+    const sanitationCallback = (message: IntermediateCatchEventFinishedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback, subscribeOnce: boolean): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.processStarted;
+
+    const sanitationCallback = (message: ProcessStartedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onProcessWithProcessModelIdStarted(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessStartedCallback,
+    processModelId: string,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.processStarted;
+
+    const sanitationCallback = (message: ProcessStartedMessage): void => {
+
+      const processModelIdsDoNotMatch = message.processModelId !== processModelId;
+      if (processModelIdsDoNotMatch) {
+        return;
+      }
+
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback, subscribeOnce: boolean): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.processEnded;
+
+    const sanitationCallback = (message: EndEventReachedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onProcessTerminated(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.processTerminated;
+
+    const sanitationCallback = (message: TerminateEndEventReachedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onProcessError(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessErrorCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.processError;
+
+    const sanitationCallback = (message: ProcessErrorMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public removeSubscription(subscription: Subscription): void {
+    this.eventAggregator.unsubscribe(subscription);
+  }
+
+  private createSubscription(eventName: string, callback: EventReceivedCallback, subscribeOnce: boolean): Subscription {
+
+    if (subscribeOnce) {
+      return this.eventAggregator.subscribeOnce(eventName, callback);
+    }
+
+    return this.eventAggregator.subscribe(eventName, callback);
+  }
+
+  private checkIfIdentityUserIDsMatch(identityA: IIdentity, identityB: IIdentity): boolean {
+    return identityA.userId === identityB.userId;
+  }
+
+  private sanitizeMessage<TPublic extends Messages.BaseEventMessage>(internalMesage: BaseSystemEventMessage): TPublic {
+
+    const sanitizedMessage = new Messages.BaseEventMessage(
+      internalMesage.correlationId,
+      internalMesage.processModelId,
+      internalMesage.processInstanceId,
+      internalMesage.flowNodeId,
+      internalMesage.flowNodeInstanceId,
+      internalMesage.currentToken,
+    );
+
+    return <TPublic> sanitizedMessage;
+  }
+
+}

--- a/src/converters/empty_activity_converter.ts
+++ b/src/converters/empty_activity_converter.ts
@@ -1,0 +1,110 @@
+import {IIdentity} from '@essential-projects/iam_contracts';
+
+import {ICorrelationService} from '@process-engine/correlation.contracts';
+import {FlowNodeInstance, ProcessTokenType} from '@process-engine/flow_node_instance.contracts';
+import {DataModels} from '@process-engine/management_api_contracts';
+import {IProcessModelFacade, IProcessModelFacadeFactory} from '@process-engine/process_engine_contracts';
+import {BpmnType, IProcessModelUseCases, Model} from '@process-engine/process_model.contracts';
+
+import * as ProcessModelCache from './process_model_cache';
+
+export class EmptyActivityConverter {
+
+  private readonly correlationService: ICorrelationService;
+  private readonly processModelUseCase: IProcessModelUseCases;
+  private readonly processModelFacadeFactory: IProcessModelFacadeFactory;
+
+  constructor(
+    correlationService: ICorrelationService,
+    processModelFacadeFactory: IProcessModelFacadeFactory,
+    processModelUseCase: IProcessModelUseCases,
+  ) {
+    this.correlationService = correlationService;
+    this.processModelFacadeFactory = processModelFacadeFactory;
+    this.processModelUseCase = processModelUseCase;
+  }
+
+  public async convert(
+    identity: IIdentity,
+    suspendedFlowNodes: Array<FlowNodeInstance>,
+  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
+
+    const suspendedEmptyActivities: Array<DataModels.EmptyActivities.EmptyActivity> = [];
+
+    for (const suspendedFlowNode of suspendedFlowNodes) {
+
+      const taskIsNotAnEmptyActivity = suspendedFlowNode.flowNodeType !== BpmnType.emptyActivity;
+      if (taskIsNotAnEmptyActivity) {
+        continue;
+      }
+
+      const processModelFacade = await this.getProcessModelForFlowNodeInstance(identity, suspendedFlowNode);
+
+      const emptyActivity = await this.convertSuspendedFlowNodeToEmptyActivity(suspendedFlowNode, processModelFacade);
+
+      suspendedEmptyActivities.push(emptyActivity);
+    }
+
+    const emptyActivityList: DataModels.EmptyActivities.EmptyActivityList = {
+      emptyActivities: suspendedEmptyActivities,
+    };
+
+    return emptyActivityList;
+  }
+
+  private async getProcessModelForFlowNodeInstance(
+    identity: IIdentity,
+    flowNodeInstance: FlowNodeInstance,
+  ): Promise<IProcessModelFacade> {
+
+    let processModel: Model.Process;
+
+    // We must store the ProcessModel for each user, to account for lane-restrictions.
+    // Some users may not be able to see some lanes that are visible to others.
+    const cacheKeyToUse = `${flowNodeInstance.processInstanceId}-${identity.userId}`;
+
+    const cacheHasMatchingEntry = ProcessModelCache.hasEntry(cacheKeyToUse);
+    if (cacheHasMatchingEntry) {
+      processModel = ProcessModelCache.get(cacheKeyToUse);
+    } else {
+      const processModelHash = await this.getProcessModelHashForProcessInstance(identity, flowNodeInstance.processInstanceId);
+      processModel = await this.processModelUseCase.getByHash(identity, flowNodeInstance.processModelId, processModelHash);
+      ProcessModelCache.add(cacheKeyToUse, processModel);
+    }
+
+    const processModelFacade = this.processModelFacadeFactory.create(processModel);
+
+    return processModelFacade;
+  }
+
+  private async getProcessModelHashForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<string> {
+    const correlationForProcessInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
+
+    // Note that ProcessInstances will only ever have one processModel and therefore only one hash attached to them.
+    return correlationForProcessInstance.processInstances[0].hash;
+  }
+
+  private async convertSuspendedFlowNodeToEmptyActivity(
+    emptyActivityInstance: FlowNodeInstance,
+    processModelFacade: IProcessModelFacade,
+  ): Promise<DataModels.EmptyActivities.EmptyActivity> {
+
+    const emptyActivityModel = processModelFacade.getFlowNodeById(emptyActivityInstance.flowNodeId);
+
+    const onSuspendToken = emptyActivityInstance.getTokenByType(ProcessTokenType.onSuspend);
+
+    const managementApiManualTask: DataModels.EmptyActivities.EmptyActivity = {
+      id: emptyActivityInstance.flowNodeId,
+      flowNodeInstanceId: emptyActivityInstance.id,
+      name: emptyActivityModel.name,
+      correlationId: emptyActivityInstance.correlationId,
+      processModelId: emptyActivityInstance.processModelId,
+      processInstanceId: emptyActivityInstance.processInstanceId,
+      tokenPayload: onSuspendToken.payload,
+    };
+
+    return managementApiManualTask;
+
+  }
+
+}

--- a/src/converters/event_converter.ts
+++ b/src/converters/event_converter.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {IIdentity} from '@essential-projects/iam_contracts';
+
+import {InternalServerError} from '@essential-projects/errors_ts';
+import {ICorrelationService} from '@process-engine/correlation.contracts';
+import {FlowNodeInstance} from '@process-engine/flow_node_instance.contracts';
+import {DataModels} from '@process-engine/management_api_contracts';
+import {IProcessModelFacade, IProcessModelFacadeFactory} from '@process-engine/process_engine_contracts';
+import {IProcessModelUseCases, Model} from '@process-engine/process_model.contracts';
+
+import * as ProcessModelCache from './process_model_cache';
+
+export class EventConverter {
+
+  private readonly correlationService: ICorrelationService;
+  private readonly processModelFacadeFactory: IProcessModelFacadeFactory;
+  private readonly processModelUseCase: IProcessModelUseCases;
+
+  constructor(
+    correlationService: ICorrelationService,
+    processModelFacadeFactory: IProcessModelFacadeFactory,
+    processModelUseCase: IProcessModelUseCases,
+  ) {
+    this.correlationService = correlationService;
+    this.processModelFacadeFactory = processModelFacadeFactory;
+    this.processModelUseCase = processModelUseCase;
+  }
+
+  public async convert(identity: IIdentity, suspendedFlowNodes: Array<FlowNodeInstance>): Promise<DataModels.Events.EventList> {
+
+    const suspendedEvents: Array<DataModels.Events.Event> = [];
+
+    for (const suspendedFlowNode of suspendedFlowNodes) {
+
+      // A triggerable suspended event will always have an eventType attached to it, to indicate what the event is waiting for.
+      // This will be either a signal or a message.
+      const flowNodeIsNotATriggerableEvent = suspendedFlowNode.eventType !== DataModels.Events.EventType.messageEvent
+                                          && suspendedFlowNode.eventType !== DataModels.Events.EventType.signalEvent;
+
+      if (flowNodeIsNotATriggerableEvent) {
+        continue;
+      }
+
+      const processModelFacade = await this.getProcessModelForFlowNodeInstance(identity, suspendedFlowNode);
+
+      const flowNodeModel = processModelFacade.getFlowNodeById(suspendedFlowNode.flowNodeId);
+
+      const event = await this.convertToManagementApiEvent(flowNodeModel as Model.Events.Event, suspendedFlowNode);
+
+      suspendedEvents.push(event);
+    }
+
+    const eventList: DataModels.Events.EventList = {
+      events: suspendedEvents,
+    };
+
+    return eventList;
+  }
+
+  private async getProcessModelForFlowNodeInstance(
+    identity: IIdentity,
+    flowNodeInstance: FlowNodeInstance,
+  ): Promise<IProcessModelFacade> {
+
+    let processModel: Model.Process;
+
+    // We must store the ProcessModel for each user, to account for lane-restrictions.
+    // Some users may not be able to see some lanes that are visible to others.
+    const cacheKeyToUse = `${flowNodeInstance.processInstanceId}-${identity.userId}`;
+
+    const cacheHasMatchingEntry = ProcessModelCache.hasEntry(cacheKeyToUse);
+    if (cacheHasMatchingEntry) {
+      processModel = ProcessModelCache.get(cacheKeyToUse);
+    } else {
+      const processModelHash = await this.getProcessModelHashForProcessInstance(identity, flowNodeInstance.processInstanceId);
+      processModel = await this.processModelUseCase.getByHash(identity, flowNodeInstance.processModelId, processModelHash);
+      ProcessModelCache.add(cacheKeyToUse, processModel);
+    }
+
+    const processModelFacade = this.processModelFacadeFactory.create(processModel);
+
+    return processModelFacade;
+  }
+
+  private async getProcessModelHashForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<string> {
+    const correlationForProcessInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
+
+    // Note that ProcessInstances will only ever have one processModel and therefore only one hash attached to them.
+    return correlationForProcessInstance.processInstances[0].hash;
+  }
+
+  private convertToManagementApiEvent(flowNodeModel: Model.Events.Event, suspendedFlowNode: FlowNodeInstance): DataModels.Events.Event {
+
+    const managementApiEvent: DataModels.Events.Event = {
+      id: suspendedFlowNode.flowNodeId,
+      flowNodeInstanceId: suspendedFlowNode.id,
+      correlationId: suspendedFlowNode.correlationId,
+      processModelId: suspendedFlowNode.processModelId,
+      processInstanceId: suspendedFlowNode.processInstanceId,
+      eventType: <DataModels.Events.EventType> suspendedFlowNode.eventType,
+      eventName: this.getEventDefinitionFromFlowNodeModel(flowNodeModel, suspendedFlowNode.eventType),
+      bpmnType: suspendedFlowNode.flowNodeType,
+    };
+
+    return managementApiEvent;
+  }
+
+  private getEventDefinitionFromFlowNodeModel(flowNodeModel: Model.Events.Event, eventType: string): string {
+
+    switch (eventType) {
+      case DataModels.Events.EventType.messageEvent:
+        return (flowNodeModel as any).messageEventDefinition.name;
+      case DataModels.Events.EventType.signalEvent:
+        return (flowNodeModel as any).signalEventDefinition.name;
+      default:
+        throw new InternalServerError(`${flowNodeModel.id} is not a triggerable event!`);
+    }
+  }
+
+}

--- a/src/converters/index.ts
+++ b/src/converters/index.ts
@@ -1,0 +1,4 @@
+export * from './empty_activity_converter';
+export * from './event_converter';
+export * from './user_task_converter';
+export * from './manual_task_converter';

--- a/src/converters/manual_task_converter.ts
+++ b/src/converters/manual_task_converter.ts
@@ -1,0 +1,110 @@
+import {IIdentity} from '@essential-projects/iam_contracts';
+
+import {ICorrelationService} from '@process-engine/correlation.contracts';
+import {FlowNodeInstance, ProcessTokenType} from '@process-engine/flow_node_instance.contracts';
+import {DataModels} from '@process-engine/management_api_contracts';
+import {IProcessModelFacade, IProcessModelFacadeFactory} from '@process-engine/process_engine_contracts';
+import {BpmnType, IProcessModelUseCases, Model} from '@process-engine/process_model.contracts';
+
+import * as ProcessModelCache from './process_model_cache';
+
+export class ManualTaskConverter {
+
+  private readonly correlationService: ICorrelationService;
+  private readonly processModelUseCase: IProcessModelUseCases;
+  private readonly processModelFacadeFactory: IProcessModelFacadeFactory;
+
+  constructor(
+    correlationService: ICorrelationService,
+    processModelFacadeFactory: IProcessModelFacadeFactory,
+    processModelUseCase: IProcessModelUseCases,
+  ) {
+    this.correlationService = correlationService;
+    this.processModelFacadeFactory = processModelFacadeFactory;
+    this.processModelUseCase = processModelUseCase;
+  }
+
+  public async convert(
+    identity: IIdentity,
+    suspendedFlowNodes: Array<FlowNodeInstance>,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
+
+    const suspendedManualTasks: Array<DataModels.ManualTasks.ManualTask> = [];
+
+    for (const suspendedFlowNode of suspendedFlowNodes) {
+
+      const taskIsNotAManualTask = suspendedFlowNode.flowNodeType !== BpmnType.manualTask;
+      if (taskIsNotAManualTask) {
+        continue;
+      }
+
+      const processModelFacade = await this.getProcessModelForFlowNodeInstance(identity, suspendedFlowNode);
+
+      const manualTask = await this.convertSuspendedFlowNodeToManualTask(suspendedFlowNode, processModelFacade);
+
+      suspendedManualTasks.push(manualTask);
+    }
+
+    const manualTaskList: DataModels.ManualTasks.ManualTaskList = {
+      manualTasks: suspendedManualTasks,
+    };
+
+    return manualTaskList;
+  }
+
+  private async getProcessModelForFlowNodeInstance(
+    identity: IIdentity,
+    flowNodeInstance: FlowNodeInstance,
+  ): Promise<IProcessModelFacade> {
+
+    let processModel: Model.Process;
+
+    // We must store the ProcessModel for each user, to account for lane-restrictions.
+    // Some users may not be able to see some lanes that are visible to others.
+    const cacheKeyToUse = `${flowNodeInstance.processInstanceId}-${identity.userId}`;
+
+    const cacheHasMatchingEntry = ProcessModelCache.hasEntry(cacheKeyToUse);
+    if (cacheHasMatchingEntry) {
+      processModel = ProcessModelCache.get(cacheKeyToUse);
+    } else {
+      const processModelHash = await this.getProcessModelHashForProcessInstance(identity, flowNodeInstance.processInstanceId);
+      processModel = await this.processModelUseCase.getByHash(identity, flowNodeInstance.processModelId, processModelHash);
+      ProcessModelCache.add(cacheKeyToUse, processModel);
+    }
+
+    const processModelFacade = this.processModelFacadeFactory.create(processModel);
+
+    return processModelFacade;
+  }
+
+  private async getProcessModelHashForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<string> {
+    const correlationForProcessInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
+
+    // Note that ProcessInstances will only ever have one processModel and therefore only one hash attached to them.
+    return correlationForProcessInstance.processInstances[0].hash;
+  }
+
+  private async convertSuspendedFlowNodeToManualTask(
+    manualTaskInstance: FlowNodeInstance,
+    processModelFacade: IProcessModelFacade,
+  ): Promise<DataModels.ManualTasks.ManualTask> {
+
+    const manualTaskModel = processModelFacade.getFlowNodeById(manualTaskInstance.flowNodeId);
+
+    const onSuspendToken = manualTaskInstance.getTokenByType(ProcessTokenType.onSuspend);
+
+    const managementApiManualTask: DataModels.ManualTasks.ManualTask = {
+      id: manualTaskInstance.flowNodeId,
+      flowNodeInstanceId: manualTaskInstance.id,
+      name: manualTaskModel.name,
+      correlationId: manualTaskInstance.correlationId,
+      processModelId: manualTaskInstance.processModelId,
+      processInstanceId: manualTaskInstance.processInstanceId,
+      tokenPayload: onSuspendToken.payload,
+    };
+
+    return managementApiManualTask;
+
+  }
+
+}

--- a/src/converters/process_model_cache.ts
+++ b/src/converters/process_model_cache.ts
@@ -1,0 +1,21 @@
+import {Model} from '@process-engine/process_model.contracts';
+
+/**
+ * Used to cache ProcessModels during conversion of suspended FlowNodeInstances.
+ * This helps to avoid repeated queries against the database for the same ProcessModel.
+ */
+type ProcessModelCache = {[cacheEntryKey: string]: Model.Process};
+
+const processModelCache: ProcessModelCache = {};
+
+export function hasEntry(cacheEntryKey: string): boolean {
+  return processModelCache[cacheEntryKey] !== undefined;
+}
+
+export function add(cacheEntryKey: string, processModel: Model.Process): void {
+  processModelCache[cacheEntryKey] = processModel;
+}
+
+export function get(cacheEntryKey: string): Model.Process {
+  return processModelCache[cacheEntryKey];
+}

--- a/src/converters/user_task_converter.ts
+++ b/src/converters/user_task_converter.ts
@@ -1,0 +1,214 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {IIdentity} from '@essential-projects/iam_contracts';
+
+import {ICorrelationService} from '@process-engine/correlation.contracts';
+import {
+  FlowNodeInstance, IFlowNodeInstanceService, ProcessToken, ProcessTokenType,
+} from '@process-engine/flow_node_instance.contracts';
+import {DataModels} from '@process-engine/management_api_contracts';
+import {
+  IFlowNodeInstanceResult,
+  IProcessModelFacade,
+  IProcessModelFacadeFactory,
+  IProcessTokenFacadeFactory,
+} from '@process-engine/process_engine_contracts';
+import {BpmnType, IProcessModelUseCases, Model} from '@process-engine/process_model.contracts';
+
+import * as ProcessModelCache from './process_model_cache';
+
+export class UserTaskConverter {
+
+  private readonly correlationService: ICorrelationService;
+  private readonly flowNodeInstanceService: IFlowNodeInstanceService;
+  private readonly processModelFacadeFactory: IProcessModelFacadeFactory;
+  private readonly processModelUseCase: IProcessModelUseCases;
+  private readonly processTokenFacadeFactory: IProcessTokenFacadeFactory;
+
+  constructor(
+    correlationRepository: ICorrelationService,
+    flowNodeInstanceService: IFlowNodeInstanceService,
+    processModelFacadeFactory: IProcessModelFacadeFactory,
+    processModelUse: IProcessModelUseCases,
+    processTokenFacadeFactory: IProcessTokenFacadeFactory,
+  ) {
+    this.correlationService = correlationRepository;
+    this.processModelUseCase = processModelUse;
+    this.flowNodeInstanceService = flowNodeInstanceService;
+    this.processModelFacadeFactory = processModelFacadeFactory;
+    this.processTokenFacadeFactory = processTokenFacadeFactory;
+  }
+
+  public async convert(
+    identity: IIdentity,
+    suspendedFlowNodes: Array<FlowNodeInstance>,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
+
+    const suspendedUserTasks: Array<DataModels.UserTasks.UserTask> = [];
+
+    for (const suspendedFlowNode of suspendedFlowNodes) {
+
+      // Note that UserTasks are not the only types of FlowNodes that can be suspended.
+      // So we must make sure that what we have here is actually a UserTask and not, for example, a TimerEvent.
+      const flowNodeIsNotAUserTask = suspendedFlowNode.flowNodeType !== BpmnType.userTask;
+      if (flowNodeIsNotAUserTask) {
+        continue;
+      }
+
+      const processModelFacade = await this.getProcessModelForFlowNodeInstance(identity, suspendedFlowNode);
+
+      const flowNodeModel = processModelFacade.getFlowNodeById(suspendedFlowNode.flowNodeId);
+
+      const userTask = await this.convertToManagementApiUserTask(flowNodeModel as Model.Activities.UserTask, suspendedFlowNode);
+
+      suspendedUserTasks.push(userTask);
+    }
+
+    const userTaskList: DataModels.UserTasks.UserTaskList = {
+      userTasks: suspendedUserTasks,
+    };
+
+    return userTaskList;
+  }
+
+  private async getProcessModelForFlowNodeInstance(
+    identity: IIdentity,
+    flowNodeInstance: FlowNodeInstance,
+  ): Promise<IProcessModelFacade> {
+
+    let processModel: Model.Process;
+
+    // We must store the ProcessModel for each user, to account for lane-restrictions.
+    // Some users may not be able to see some lanes that are visible to others.
+    const cacheKeyToUse = `${flowNodeInstance.processInstanceId}-${identity.userId}`;
+
+    const cacheHasMatchingEntry = ProcessModelCache.hasEntry(cacheKeyToUse);
+    if (cacheHasMatchingEntry) {
+      processModel = ProcessModelCache.get(cacheKeyToUse);
+    } else {
+      const processModelHash = await this.getProcessModelHashForProcessInstance(identity, flowNodeInstance.processInstanceId);
+      processModel = await this.processModelUseCase.getByHash(identity, flowNodeInstance.processModelId, processModelHash);
+      ProcessModelCache.add(cacheKeyToUse, processModel);
+    }
+
+    const processModelFacade = this.processModelFacadeFactory.create(processModel);
+
+    return processModelFacade;
+  }
+
+  private async getProcessModelHashForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<string> {
+    const correlationForProcessInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
+
+    // Note that ProcessInstances will only ever have one processModel and therefore only one hash attached to them.
+    return correlationForProcessInstance.processInstances[0].hash;
+  }
+
+  private async convertToManagementApiUserTask(
+    userTaskModel: Model.Activities.UserTask,
+    userTaskInstance: FlowNodeInstance,
+  ): Promise<DataModels.UserTasks.UserTask> {
+
+    const currentUserTaskToken = userTaskInstance.getTokenByType(ProcessTokenType.onSuspend);
+
+    const userTaskTokenOldFormat = await this.getUserTaskTokenInOldFormat(currentUserTaskToken);
+
+    const userTaskFormFields =
+      userTaskModel.formFields.map((formField: Model.Activities.Types.UserTaskFormField): DataModels.UserTasks.UserTaskFormField => {
+        return this.convertToManagementApiFormField(formField, userTaskTokenOldFormat);
+      });
+
+    const userTaskConfig: DataModels.UserTasks.UserTaskConfig = {
+      formFields: userTaskFormFields,
+      preferredControl: this.evaluateExpressionWithOldToken(userTaskModel.preferredControl, userTaskTokenOldFormat),
+      description: userTaskModel.description,
+      finishedMessage: userTaskModel.finishedMessage,
+    };
+
+    const managementApiUserTask: DataModels.UserTasks.UserTask = {
+      id: userTaskInstance.flowNodeId,
+      flowNodeInstanceId: userTaskInstance.id,
+      name: userTaskModel.name,
+      correlationId: userTaskInstance.correlationId,
+      processModelId: userTaskInstance.processModelId,
+      processInstanceId: userTaskInstance.processInstanceId,
+      data: userTaskConfig,
+      tokenPayload: currentUserTaskToken.payload,
+    };
+
+    return managementApiUserTask;
+  }
+
+  private convertToManagementApiFormField(
+    formField: Model.Activities.Types.UserTaskFormField,
+    oldTokenFormat: any,
+  ): DataModels.UserTasks.UserTaskFormField {
+
+    const userTaskFormField = new DataModels.UserTasks.UserTaskFormField();
+    userTaskFormField.id = formField.id;
+    userTaskFormField.label = this.evaluateExpressionWithOldToken(formField.label, oldTokenFormat);
+    userTaskFormField.type = DataModels.UserTasks.UserTaskFormFieldType[formField.type];
+    userTaskFormField.enumValues = formField.enumValues;
+    userTaskFormField.defaultValue = this.evaluateExpressionWithOldToken(formField.defaultValue, oldTokenFormat);
+    userTaskFormField.preferredControl = this.evaluateExpressionWithOldToken(formField.preferredControl, oldTokenFormat);
+
+    return userTaskFormField;
+  }
+
+  private evaluateExpressionWithOldToken(expression: string, oldTokenFormat: any): string | null {
+
+    let result: any = expression;
+
+    if (!expression) {
+      return result;
+    }
+
+    const expressionStartsOn = '${';
+    const expressionEndsOn = '}';
+
+    const isExpression = expression.charAt(0) === '$';
+    if (isExpression === false) {
+      return result;
+    }
+
+    const finalExpressionLength = expression.length - expressionStartsOn.length - expressionEndsOn.length;
+    const expressionBody = expression.substr(expressionStartsOn.length, finalExpressionLength);
+
+    const functionString = `return ${expressionBody}`;
+    const scriptFunction = new Function('token', functionString);
+
+    result = scriptFunction.call(undefined, oldTokenFormat);
+
+    return result;
+  }
+
+  private async getUserTaskTokenInOldFormat(currentProcessToken: ProcessToken): Promise<any> {
+
+    const {
+      processInstanceId, processModelId, correlationId, identity,
+    } = currentProcessToken;
+
+    const processInstanceTokens = await this.flowNodeInstanceService.queryProcessTokensByProcessInstanceId(processInstanceId);
+
+    const filteredInstanceTokens = processInstanceTokens.filter((token: ProcessToken): boolean => {
+      return token.type === ProcessTokenType.onExit;
+    });
+
+    const processTokenFacade = this.processTokenFacadeFactory.create(processInstanceId, processModelId, correlationId, identity);
+
+    const processTokenResultPromises = filteredInstanceTokens.map(async (processToken: ProcessToken): Promise<IFlowNodeInstanceResult> => {
+      const processTokenFlowNodeInstance = await this.flowNodeInstanceService.queryByInstanceId(processToken.flowNodeInstanceId);
+
+      return {
+        flowNodeInstanceId: processTokenFlowNodeInstance.id,
+        flowNodeId: processTokenFlowNodeInstance.flowNodeId,
+        result: processToken.payload,
+      };
+    });
+
+    const processTokenResults = await Promise.all(processTokenResultPromises);
+
+    processTokenFacade.importResults(processTokenResults);
+
+    return processTokenFacade.getOldTokenFormat();
+  }
+
+}

--- a/src/empty_activity_service.ts
+++ b/src/empty_activity_service.ts
@@ -1,30 +1,73 @@
-import {Subscription} from '@essential-projects/event_aggregator_contracts';
-import {IIdentity} from '@essential-projects/iam_contracts';
-
-import {APIs as ConsumerApis} from '@process-engine/consumer_api_contracts';
+import * as EssentialProjectErrors from '@essential-projects/errors_ts';
+import {IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
+import {IIAMService, IIdentity} from '@essential-projects/iam_contracts';
 import {APIs, DataModels, Messages} from '@process-engine/management_api_contracts';
+import {
+  FlowNodeInstance,
+  FlowNodeInstanceState,
+  IFlowNodeInstanceService,
+} from '@process-engine/flow_node_instance.contracts';
+import {FinishEmptyActivityMessage as InternalFinishEmptyActivityMessage} from '@process-engine/process_engine_contracts';
+
+import {NotificationAdapter} from './adapters/index';
+import {EmptyActivityConverter} from './converters/index';
 
 export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
 
-  private readonly consumerApiEmptyActivityService: ConsumerApis.IEmptyActivityConsumerApi;
+  private readonly eventAggregator: IEventAggregator;
+  private readonly flowNodeInstanceService: IFlowNodeInstanceService;
+  private readonly iamService: IIAMService;
 
-  constructor(consumerApiEmptyActivityService: ConsumerApis.IEmptyActivityConsumerApi) {
-    this.consumerApiEmptyActivityService = consumerApiEmptyActivityService;
+  private readonly notificationAdapter: NotificationAdapter;
+
+  private readonly emptyActivityConverter: EmptyActivityConverter;
+
+  private readonly canSubscribeToEventsClaim = 'can_subscribe_to_events';
+
+  constructor(
+    eventAggregator: IEventAggregator,
+    flowNodeInstanceService: IFlowNodeInstanceService,
+    iamService: IIAMService,
+    notificationAdapter: NotificationAdapter,
+    emptyActivityConverter: EmptyActivityConverter,
+  ) {
+    this.eventAggregator = eventAggregator;
+    this.flowNodeInstanceService = flowNodeInstanceService;
+    this.iamService = iamService;
+
+    this.notificationAdapter = notificationAdapter;
+
+    this.emptyActivityConverter = emptyActivityConverter;
   }
 
   public async getEmptyActivitiesForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    return this.consumerApiEmptyActivityService.getEmptyActivitiesForProcessModel(identity, processModelId);
+
+    const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByProcessModel(processModelId);
+
+    const emptyActivityList = await this.emptyActivityConverter.convert(identity, suspendedFlowNodes);
+
+    return emptyActivityList;
   }
 
   public async getEmptyActivitiesForProcessInstance(
     identity: IIdentity,
     processInstanceId: string,
   ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    return this.consumerApiEmptyActivityService.getEmptyActivitiesForProcessInstance(identity, processInstanceId);
+
+    const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByProcessInstance(processInstanceId);
+
+    const emptyActivityList = await this.emptyActivityConverter.convert(identity, suspendedFlowNodes);
+
+    return emptyActivityList;
   }
 
   public async getEmptyActivitiesForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    return this.consumerApiEmptyActivityService.getEmptyActivitiesForCorrelation(identity, correlationId);
+
+    const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByCorrelation(correlationId);
+
+    const emptyActivityList = await this.emptyActivityConverter.convert(identity, suspendedFlowNodes);
+
+    return emptyActivityList;
   }
 
   public async getEmptyActivitiesForProcessModelInCorrelation(
@@ -32,7 +75,29 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
     processModelId: string,
     correlationId: string,
   ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    return this.consumerApiEmptyActivityService.getEmptyActivitiesForProcessModelInCorrelation(identity, processModelId, correlationId);
+
+    const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByCorrelation(correlationId);
+
+    const suspendedProcessModelFlowNodes = suspendedFlowNodes.filter((flowNodeInstance: FlowNodeInstance): boolean => {
+      return flowNodeInstance.tokens[0].processModelId === processModelId;
+    });
+
+    const emptyActivityList = await this.emptyActivityConverter.convert(identity, suspendedProcessModelFlowNodes);
+
+    return emptyActivityList;
+  }
+
+  public async getWaitingEmptyActivitiesByIdentity(identity: IIdentity): Promise<DataModels.EmptyActivities.EmptyActivityList> {
+
+    const suspendedFlowNodeInstances = await this.flowNodeInstanceService.queryByState(FlowNodeInstanceState.suspended);
+
+    const flowNodeInstancesOwnedByUser = suspendedFlowNodeInstances.filter((flowNodeInstance: FlowNodeInstance): boolean => {
+      return this.checkIfIdentityUserIDsMatch(identity, flowNodeInstance.owner);
+    });
+
+    const emptyActivityList = await this.emptyActivityConverter.convert(identity, flowNodeInstancesOwnedByUser);
+
+    return emptyActivityList;
   }
 
   public async finishEmptyActivity(
@@ -41,16 +106,47 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
     correlationId: string,
     emptyActivityInstanceId: string,
   ): Promise<void> {
-    return this.consumerApiEmptyActivityService.finishEmptyActivity(identity, processInstanceId, correlationId, emptyActivityInstanceId);
+
+    const matchingFlowNodeInstance =
+      await this.getFlowNodeInstanceForCorrelationInProcessInstance(correlationId, processInstanceId, emptyActivityInstanceId);
+
+    const noMatchingInstanceFound = matchingFlowNodeInstance === undefined;
+    if (noMatchingInstanceFound) {
+      const errorMessage =
+        // eslint-disable-next-line max-len
+        `ProcessInstance '${processInstanceId}' in Correlation '${correlationId}' does not have an EmptyActivity with id '${emptyActivityInstanceId}'`;
+      throw new EssentialProjectErrors.NotFoundError(errorMessage);
+    }
+
+    const convertedEmptyActivityList = await this.emptyActivityConverter.convert(identity, [matchingFlowNodeInstance]);
+
+    const matchingEmptyActivity = convertedEmptyActivityList.emptyActivities[0];
+
+    return new Promise<void>((resolve: Function): void => {
+      const routePrameter: {[name: string]: string} = Messages.EventAggregatorSettings.messageParams;
+
+      const emptyActivityFinishedEvent = Messages.EventAggregatorSettings
+        .messagePaths.emptyActivityWithInstanceIdFinished
+        .replace(routePrameter.correlationId, correlationId)
+        .replace(routePrameter.processInstanceId, processInstanceId)
+        .replace(routePrameter.flowNodeInstanceId, emptyActivityInstanceId);
+
+      this.eventAggregator.subscribeOnce(emptyActivityFinishedEvent, (): void => {
+        resolve();
+      });
+
+      this.publishFinishEmptyActivityEvent(identity, matchingEmptyActivity);
+    });
   }
 
-  // Notifications
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiEmptyActivityService.onEmptyActivityWaiting(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onEmptyActivityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onEmptyActivityFinished(
@@ -58,7 +154,9 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
     callback: Messages.CallbackTypes.OnEmptyActivityFinishedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiEmptyActivityService.onEmptyActivityFinished(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onEmptyActivityFinished(identity, callback, subscribeOnce);
   }
 
   public async onEmptyActivityForIdentityWaiting(
@@ -66,7 +164,9 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiEmptyActivityService.onEmptyActivityForIdentityWaiting(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onEmptyActivityForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onEmptyActivityForIdentityFinished(
@@ -74,7 +174,52 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
     callback: Messages.CallbackTypes.OnEmptyActivityFinishedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiEmptyActivityService.onEmptyActivityForIdentityFinished(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onEmptyActivityForIdentityFinished(identity, callback, subscribeOnce);
+  }
+
+  private async getFlowNodeInstanceForCorrelationInProcessInstance(
+    correlationId: string,
+    processInstanceId: string,
+    instanceId: string,
+  ): Promise<FlowNodeInstance> {
+
+    const suspendedFlowNodeInstances = await this.flowNodeInstanceService.querySuspendedByProcessInstance(processInstanceId);
+
+    const matchingInstance = suspendedFlowNodeInstances.find((instance: FlowNodeInstance): boolean => {
+      return instance.id === instanceId &&
+             instance.correlationId === correlationId;
+    });
+
+    return matchingInstance;
+  }
+
+  private checkIfIdentityUserIDsMatch(identityA: IIdentity, identityB: IIdentity): boolean {
+    return identityA.userId === identityB.userId;
+  }
+
+  private publishFinishEmptyActivityEvent(
+    identity: IIdentity,
+    emptyActivityInstance: DataModels.EmptyActivities.EmptyActivity,
+  ): void {
+
+    const finishEmptyActivityMessage = new InternalFinishEmptyActivityMessage(
+      emptyActivityInstance.correlationId,
+      emptyActivityInstance.processModelId,
+      emptyActivityInstance.processInstanceId,
+      emptyActivityInstance.id,
+      emptyActivityInstance.flowNodeInstanceId,
+      identity,
+      emptyActivityInstance.tokenPayload,
+    );
+
+    const finishEmptyActivityEvent = Messages.EventAggregatorSettings.messagePaths.finishEmptyActivity
+      .replace(Messages.EventAggregatorSettings.messageParams.correlationId, emptyActivityInstance.correlationId)
+      .replace(Messages.EventAggregatorSettings.messageParams.processInstanceId, emptyActivityInstance.processInstanceId)
+      .replace(Messages.EventAggregatorSettings.messageParams.flowNodeInstanceId, emptyActivityInstance.flowNodeInstanceId);
+
+    this.eventAggregator.publish(finishEmptyActivityEvent, finishEmptyActivityMessage);
   }
 
 }

--- a/src/event_service.ts
+++ b/src/event_service.ts
@@ -1,22 +1,67 @@
-import {IIdentity} from '@essential-projects/iam_contracts';
+import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
+import {IIAMService, IIdentity} from '@essential-projects/iam_contracts';
+import {FlowNodeInstance, IFlowNodeInstanceService} from '@process-engine/flow_node_instance.contracts';
+import {APIs, DataModels, Messages} from '@process-engine/management_api_contracts';
+import {IProcessModelUseCases} from '@process-engine/process_model.contracts';
 
-import {APIs as ConsumerApis} from '@process-engine/consumer_api_contracts';
-import {APIs, DataModels} from '@process-engine/management_api_contracts';
+import {EventConverter} from './converters/index';
 
 export class EventService implements APIs.IEventManagementApi {
 
-  private readonly consumerApiEventService: ConsumerApis.IEventConsumerApi;
+  private readonly eventAggregator: IEventAggregator;
+  private readonly eventConverter: EventConverter;
+  private readonly flowNodeInstanceService: IFlowNodeInstanceService;
+  private readonly iamService: IIAMService;
+  private readonly processModelUseCase: IProcessModelUseCases;
 
-  constructor(consumerApiEventService: ConsumerApis.IEventConsumerApi) {
-    this.consumerApiEventService = consumerApiEventService;
+  private readonly canTriggerMessagesClaim = 'can_trigger_messages';
+  private readonly canTriggerSignalsClaim = 'can_trigger_signals';
+
+  constructor(
+    eventAggregator: IEventAggregator,
+    flowNodeInstanceService: IFlowNodeInstanceService,
+    iamService: IIAMService,
+    processModelUseCase: IProcessModelUseCases,
+    eventConverter: EventConverter,
+  ) {
+    this.eventAggregator = eventAggregator;
+    this.flowNodeInstanceService = flowNodeInstanceService;
+    this.iamService = iamService;
+    this.processModelUseCase = processModelUseCase;
+    this.eventConverter = eventConverter;
   }
 
   public async getWaitingEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
-    return this.consumerApiEventService.getEventsForProcessModel(identity, processModelId);
+
+    const suspendedFlowNodeInstances = await this.flowNodeInstanceService.querySuspendedByProcessModel(processModelId);
+
+    const suspendedEvents = suspendedFlowNodeInstances.filter(this.isFlowNodeAnEvent);
+
+    const eventList = await this.eventConverter.convert(identity, suspendedEvents);
+
+    return eventList;
   }
 
   public async getWaitingEventsForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.Events.EventList> {
-    return this.consumerApiEventService.getEventsForCorrelation(identity, correlationId);
+
+    const suspendedFlowNodeInstances = await this.flowNodeInstanceService.querySuspendedByCorrelation(correlationId);
+
+    const suspendedEvents = suspendedFlowNodeInstances.filter(this.isFlowNodeAnEvent);
+
+    const accessibleEvents = await Promise.filter(suspendedEvents, async (flowNode: FlowNodeInstance): Promise<boolean> => {
+      try {
+        await this.processModelUseCase.getProcessModelById(identity, flowNode.processModelId);
+
+        return true;
+      } catch (error) {
+
+        return false;
+      }
+    });
+
+    const eventList = await this.eventConverter.convert(identity, accessibleEvents);
+
+    return eventList;
   }
 
   public async getWaitingEventsForProcessModelInCorrelation(
@@ -25,15 +70,43 @@ export class EventService implements APIs.IEventManagementApi {
     correlationId: string,
   ): Promise<DataModels.Events.EventList> {
 
-    return this.consumerApiEventService.getEventsForProcessModelInCorrelation(identity, processModelId, correlationId);
+    const suspendedFlowNodeInstances = await this.flowNodeInstanceService.querySuspendedByCorrelation(correlationId);
+
+    const suspendedEvents = suspendedFlowNodeInstances.filter((flowNode: FlowNodeInstance): boolean => {
+
+      const flowNodeIsEvent = this.isFlowNodeAnEvent(flowNode);
+      const flowNodeBelongstoCorrelation = flowNode.processModelId === processModelId;
+
+      return flowNodeIsEvent && flowNodeBelongstoCorrelation;
+    });
+
+    const triggerableEvents = await this.eventConverter.convert(identity, suspendedEvents);
+
+    return triggerableEvents;
   }
 
   public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
-    return this.consumerApiEventService.triggerMessageEvent(identity, messageName, payload);
+
+    await this.iamService.ensureHasClaim(identity, this.canTriggerMessagesClaim);
+
+    const messageEventName = Messages.EventAggregatorSettings.messagePaths.messageEventReached
+      .replace(Messages.EventAggregatorSettings.messageParams.messageReference, messageName);
+
+    this.eventAggregator.publish(messageEventName, payload);
   }
 
   public async triggerSignalEvent(identity: IIdentity, signalName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
-    return this.consumerApiEventService.triggerSignalEvent(identity, signalName, payload);
+
+    await this.iamService.ensureHasClaim(identity, this.canTriggerSignalsClaim);
+
+    const signalEventName = Messages.EventAggregatorSettings.messagePaths.signalEventReached
+      .replace(Messages.EventAggregatorSettings.messageParams.signalReference, signalName);
+
+    this.eventAggregator.publish(signalEventName, payload);
+  }
+
+  private isFlowNodeAnEvent(flowNodeInstance: FlowNodeInstance): boolean {
+    return flowNodeInstance.eventType !== undefined;
   }
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './adapters/index';
+export * from './converters/index';
 
 export * from './correlation_service';
 export * from './cronjob_service';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export * from './adapters/index';
+
 export * from './correlation_service';
 export * from './cronjob_service';
 export * from './empty_activity_service';

--- a/src/notification_service.ts
+++ b/src/notification_service.ts
@@ -1,15 +1,23 @@
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
-import {IIdentity} from '@essential-projects/iam_contracts';
+import {IIAMService, IIdentity} from '@essential-projects/iam_contracts';
 
-import {APIs as ConsumerApis} from '@process-engine/consumer_api_contracts';
 import {APIs, Messages} from '@process-engine/management_api_contracts';
+
+import {NotificationAdapter} from './adapters/index';
 
 export class NotificationService implements APIs.INotificationManagementApi {
 
-  private readonly consumerApiNotificationService: ConsumerApis.INotificationConsumerApi;
+  private readonly iamService: IIAMService;
+  private readonly notificationAdapter: NotificationAdapter;
 
-  constructor(consumerApiNotificationService: ConsumerApis.INotificationConsumerApi) {
-    this.consumerApiNotificationService = consumerApiNotificationService;
+  private readonly canSubscribeToEventsClaim = 'can_subscribe_to_events';
+
+  constructor(
+    iamService: IIAMService,
+    notificationAdapter: NotificationAdapter,
+  ) {
+    this.iamService = iamService;
+    this.notificationAdapter = notificationAdapter;
   }
 
   // Notifications
@@ -18,7 +26,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnActivityReachedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onActivityReached(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onActivityReached(identity, callback, subscribeOnce);
   }
 
   public async onActivityFinished(
@@ -26,7 +36,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnActivityFinishedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onActivityFinished(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onActivityFinished(identity, callback, subscribeOnce);
   }
 
   public async onEmptyActivityWaiting(
@@ -34,7 +46,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onEmptyActivityWaiting(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onEmptyActivityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onEmptyActivityFinished(
@@ -42,7 +56,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnEmptyActivityFinishedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onEmptyActivityFinished(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onEmptyActivityFinished(identity, callback, subscribeOnce);
   }
 
   public async onEmptyActivityForIdentityWaiting(
@@ -50,7 +66,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onEmptyActivityForIdentityWaiting(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onEmptyActivityForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onEmptyActivityForIdentityFinished(
@@ -58,7 +76,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnEmptyActivityFinishedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onEmptyActivityForIdentityFinished(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onEmptyActivityForIdentityFinished(identity, callback, subscribeOnce);
   }
 
   public async onUserTaskWaiting(
@@ -66,7 +86,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onUserTaskWaiting(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onUserTaskWaiting(identity, callback, subscribeOnce);
   }
 
   public async onUserTaskFinished(
@@ -74,7 +96,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onUserTaskFinished(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onUserTaskFinished(identity, callback, subscribeOnce);
   }
 
   public async onUserTaskForIdentityWaiting(
@@ -82,7 +106,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onUserTaskForIdentityFinished(
@@ -90,7 +116,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
   public async onBoundaryEventTriggered(
@@ -98,7 +126,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnBoundaryEventTriggeredCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onBoundaryEventTriggered(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onBoundaryEventTriggered(identity, callback, subscribeOnce);
   }
 
   public async onIntermediateThrowEventTriggered(
@@ -106,7 +136,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnIntermediateThrowEventTriggeredCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onIntermediateThrowEventTriggered(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onIntermediateThrowEventTriggered(identity, callback, subscribeOnce);
   }
 
   public async onIntermediateCatchEventReached(
@@ -114,7 +146,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnIntermediateCatchEventReachedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onIntermediateCatchEventReached(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onIntermediateCatchEventReached(identity, callback, subscribeOnce);
   }
 
   public async onIntermediateCatchEventFinished(
@@ -122,7 +156,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnIntermediateCatchEventFinishedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onIntermediateCatchEventFinished(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onIntermediateCatchEventFinished(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskWaiting(
@@ -130,7 +166,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onManualTaskWaiting(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onManualTaskWaiting(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskFinished(
@@ -138,7 +176,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onManualTaskFinished(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onManualTaskFinished(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskForIdentityWaiting(
@@ -146,7 +186,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskForIdentityFinished(
@@ -154,7 +196,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
   public async onProcessStarted(
@@ -162,7 +206,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnProcessEndedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onProcessStarted(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onProcessStarted(identity, callback, subscribeOnce);
   }
 
   public async onProcessWithProcessModelIdStarted(
@@ -171,7 +217,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     processModelId: string,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onProcessWithProcessModelIdStarted(identity, callback, processModelId, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onProcessWithProcessModelIdStarted(identity, callback, processModelId, subscribeOnce);
   }
 
   public async onProcessTerminated(
@@ -179,7 +227,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onProcessTerminated(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onProcessTerminated(identity, callback, subscribeOnce);
   }
 
   public async onProcessError(
@@ -187,7 +237,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnProcessErrorCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onProcessError(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onProcessError(identity, callback, subscribeOnce);
   }
 
   public async onProcessEnded(
@@ -195,11 +247,13 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnProcessEndedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onProcessEnded(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onProcessEnded(identity, callback, subscribeOnce);
   }
 
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
-    return this.consumerApiNotificationService.removeSubscription(identity, subscription);
+    return this.notificationAdapter.removeSubscription(subscription);
   }
 
   // -------------- For backwards compatibility only
@@ -209,7 +263,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onCallActivityWaiting(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onCallActivityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onCallActivityFinished(
@@ -217,7 +273,9 @@ export class NotificationService implements APIs.INotificationManagementApi {
     callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    return this.consumerApiNotificationService.onCallActivityFinished(identity, callback, subscribeOnce);
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onCallActivityFinished(identity, callback, subscribeOnce);
   }
 
   // --------------

--- a/src/user_task_service.ts
+++ b/src/user_task_service.ts
@@ -1,27 +1,116 @@
-import {Subscription} from '@essential-projects/event_aggregator_contracts';
-import {IIdentity} from '@essential-projects/iam_contracts';
-
-import {APIs as ConsumerApis} from '@process-engine/consumer_api_contracts';
+import * as EssentialProjectErrors from '@essential-projects/errors_ts';
+import {IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
+import {IIAMService, IIdentity} from '@essential-projects/iam_contracts';
+import {
+  FlowNodeInstance,
+  FlowNodeInstanceState,
+  IFlowNodeInstanceService,
+} from '@process-engine/flow_node_instance.contracts';
 import {APIs, DataModels, Messages} from '@process-engine/management_api_contracts';
+import {FinishUserTaskMessage as InternalFinishUserTaskMessage} from '@process-engine/process_engine_contracts';
+
+import {NotificationAdapter} from './adapters/index';
+import {UserTaskConverter} from './converters/index';
 
 export class UserTaskService implements APIs.IUserTaskManagementApi {
 
-  private readonly consumerApiUserTaskService: ConsumerApis.IUserTaskConsumerApi;
+  private readonly eventAggregator: IEventAggregator;
+  private readonly flowNodeInstanceService: IFlowNodeInstanceService;
+  private readonly iamService: IIAMService;
 
-  constructor(consumerApiUserTaskService: ConsumerApis.IUserTaskConsumerApi) {
-    this.consumerApiUserTaskService = consumerApiUserTaskService;
+  private readonly notificationAdapter: NotificationAdapter;
+
+  private readonly userTaskConverter: UserTaskConverter;
+
+  private readonly canSubscribeToEventsClaim = 'can_subscribe_to_events';
+
+  constructor(
+    eventAggregator: IEventAggregator,
+    flowNodeInstanceService: IFlowNodeInstanceService,
+    iamService: IIAMService,
+    notificationAdapter: NotificationAdapter,
+    userTaskConverter: UserTaskConverter,
+  ) {
+    this.eventAggregator = eventAggregator;
+    this.flowNodeInstanceService = flowNodeInstanceService;
+    this.iamService = iamService;
+
+    this.notificationAdapter = notificationAdapter;
+
+    this.userTaskConverter = userTaskConverter;
+  }
+
+  public async onUserTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce = false,
+  ): Promise<Subscription> {
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onUserTaskWaiting(identity, callback, subscribeOnce);
+  }
+
+  public async onUserTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce = false,
+  ): Promise<Subscription> {
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onUserTaskFinished(identity, callback, subscribeOnce);
+  }
+
+  public async onUserTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce = false,
+  ): Promise<Subscription> {
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
+  }
+
+  public async onUserTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce = false,
+  ): Promise<Subscription> {
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
+  }
+
+  public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    this.notificationAdapter.removeSubscription(subscription);
   }
 
   public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    return this.consumerApiUserTaskService.getUserTasksForProcessModel(identity, processModelId);
+
+    const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByProcessModel(processModelId);
+
+    const userTaskList = await this.userTaskConverter.convert(identity, suspendedFlowNodes);
+
+    return userTaskList;
   }
 
   public async getUserTasksForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    return this.consumerApiUserTaskService.getUserTasksForProcessInstance(identity, processInstanceId);
+
+    const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByProcessInstance(processInstanceId);
+
+    const userTaskList = await this.userTaskConverter.convert(identity, suspendedFlowNodes);
+
+    return userTaskList;
   }
 
   public async getUserTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    return this.consumerApiUserTaskService.getUserTasksForCorrelation(identity, correlationId);
+
+    const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByCorrelation(correlationId);
+
+    const userTaskList = await this.userTaskConverter.convert(identity, suspendedFlowNodes);
+
+    return userTaskList;
   }
 
   public async getUserTasksForProcessModelInCorrelation(
@@ -29,7 +118,36 @@ export class UserTaskService implements APIs.IUserTaskManagementApi {
     processModelId: string,
     correlationId: string,
   ): Promise<DataModels.UserTasks.UserTaskList> {
-    return this.consumerApiUserTaskService.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
+
+    const flowNodeInstances = await this.flowNodeInstanceService.queryActiveByCorrelationAndProcessModel(correlationId, processModelId);
+
+    const suspendedFlowNodeInstances = flowNodeInstances.filter((flowNodeInstance: FlowNodeInstance): boolean => {
+      return flowNodeInstance.state === FlowNodeInstanceState.suspended;
+    });
+
+    const noSuspendedFlowNodesFound = !suspendedFlowNodeInstances || suspendedFlowNodeInstances.length === 0;
+    if (noSuspendedFlowNodesFound) {
+      return <DataModels.UserTasks.UserTaskList> {
+        userTasks: [],
+      };
+    }
+
+    const userTaskList = await this.userTaskConverter.convert(identity, suspendedFlowNodeInstances);
+
+    return userTaskList;
+  }
+
+  public async getWaitingUserTasksByIdentity(identity: IIdentity): Promise<DataModels.UserTasks.UserTaskList> {
+
+    const suspendedFlowNodeInstances = await this.flowNodeInstanceService.queryByState(FlowNodeInstanceState.suspended);
+
+    const flowNodeInstancesOwnedByUser = suspendedFlowNodeInstances.filter((flowNodeInstance: FlowNodeInstance): boolean => {
+      return this.checkIfIdentityUserIDsMatch(identity, flowNodeInstance.owner);
+    });
+
+    const userTaskList = await this.userTaskConverter.convert(identity, flowNodeInstancesOwnedByUser);
+
+    return userTaskList;
   }
 
   public async finishUserTask(
@@ -37,42 +155,103 @@ export class UserTaskService implements APIs.IUserTaskManagementApi {
     processInstanceId: string,
     correlationId: string,
     userTaskInstanceId: string,
-    userTaskResult: DataModels.UserTasks.UserTaskResult,
+    userTaskResult?: DataModels.UserTasks.UserTaskResult,
   ): Promise<void> {
-    return this.consumerApiUserTaskService.finishUserTask(identity, processInstanceId, correlationId, userTaskInstanceId, userTaskResult);
+
+    const resultForProcessEngine = this.createUserTaskResultForProcessEngine(userTaskResult);
+
+    const matchingFlowNodeInstance =
+      await this.getFlowNodeInstanceForCorrelationInProcessInstance(correlationId, processInstanceId, userTaskInstanceId);
+
+    const noMatchingInstanceFound = matchingFlowNodeInstance === undefined;
+    if (noMatchingInstanceFound) {
+      const errorMessage =
+        `ProcessInstance '${processInstanceId}' in Correlation '${correlationId}' does not have a UserTask with id '${userTaskInstanceId}'`;
+      throw new EssentialProjectErrors.NotFoundError(errorMessage);
+    }
+
+    const convertedUserTaskList = await this.userTaskConverter.convert(identity, [matchingFlowNodeInstance]);
+
+    const matchingUserTask = convertedUserTaskList.userTasks[0];
+
+    return new Promise<void>((resolve: Function): void => {
+
+      const userTaskFinishedEvent = Messages.EventAggregatorSettings.messagePaths.userTaskWithInstanceIdFinished
+        .replace(Messages.EventAggregatorSettings.messageParams.correlationId, correlationId)
+        .replace(Messages.EventAggregatorSettings.messageParams.processInstanceId, processInstanceId)
+        .replace(Messages.EventAggregatorSettings.messageParams.flowNodeInstanceId, userTaskInstanceId);
+
+      this.eventAggregator.subscribeOnce(userTaskFinishedEvent, (): void => {
+        resolve();
+      });
+
+      this.publishFinishUserTaskEvent(identity, matchingUserTask, resultForProcessEngine);
+    });
   }
 
-  // Notifications
-  public async onUserTaskWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
-    subscribeOnce?: boolean,
-  ): Promise<Subscription> {
-    return this.consumerApiUserTaskService.onUserTaskWaiting(identity, callback, subscribeOnce);
+  private async getFlowNodeInstanceForCorrelationInProcessInstance(
+    correlationId: string,
+    processInstanceId: string,
+    instanceId: string,
+  ): Promise<FlowNodeInstance> {
+
+    const suspendedFlowNodeInstances = await this.flowNodeInstanceService.querySuspendedByProcessInstance(processInstanceId);
+
+    const matchingInstance = suspendedFlowNodeInstances.find((instance: FlowNodeInstance): boolean => {
+      return instance.id === instanceId &&
+             instance.correlationId === correlationId;
+    });
+
+    return matchingInstance;
   }
 
-  public async onUserTaskFinished(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
-    subscribeOnce?: boolean,
-  ): Promise<Subscription> {
-    return this.consumerApiUserTaskService.onUserTaskFinished(identity, callback, subscribeOnce);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private createUserTaskResultForProcessEngine(finishedTask: DataModels.UserTasks.UserTaskResult): any {
+
+    const noResultsProvided = !finishedTask || !finishedTask.formFields;
+
+    if (noResultsProvided) {
+      return {};
+    }
+
+    const formFieldResultIsNotAnObject = typeof finishedTask !== 'object'
+      || typeof finishedTask.formFields !== 'object'
+      || Array.isArray(finishedTask.formFields);
+
+    if (formFieldResultIsNotAnObject) {
+      throw new EssentialProjectErrors.BadRequestError('The UserTask\'s FormFields are not an object.');
+    }
+
+    return finishedTask.formFields;
   }
 
-  public async onUserTaskForIdentityWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
-    subscribeOnce?: boolean,
-  ): Promise<Subscription> {
-    return this.consumerApiUserTaskService.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
+  private checkIfIdentityUserIDsMatch(identityA: IIdentity, identityB: IIdentity): boolean {
+    return identityA.userId === identityB.userId;
   }
 
-  public async onUserTaskForIdentityFinished(
+  private publishFinishUserTaskEvent(
     identity: IIdentity,
-    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
-    subscribeOnce?: boolean,
-  ): Promise<Subscription> {
-    return this.consumerApiUserTaskService.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
+    userTaskInstance: DataModels.UserTasks.UserTask,
+    userTaskResult: DataModels.UserTasks.UserTaskResult,
+  ): void {
+
+    const finishUserTaskMessage = new InternalFinishUserTaskMessage(
+      userTaskResult,
+      userTaskInstance.correlationId,
+      userTaskInstance.processModelId,
+      userTaskInstance.processInstanceId,
+      userTaskInstance.id,
+      userTaskInstance.flowNodeInstanceId,
+      identity,
+      userTaskInstance.tokenPayload,
+    );
+
+    const finishUserTaskEvent = Messages.EventAggregatorSettings.messagePaths.finishUserTask
+      .replace(Messages.EventAggregatorSettings.messageParams.correlationId, userTaskInstance.correlationId)
+      .replace(Messages.EventAggregatorSettings.messageParams.processInstanceId, userTaskInstance.processInstanceId)
+      .replace(Messages.EventAggregatorSettings.messageParams.flowNodeInstanceId, userTaskInstance.flowNodeInstanceId);
+
+    this.eventAggregator.publish(finishUserTaskEvent, finishUserTaskMessage);
   }
 
 }


### PR DESCRIPTION
## Changes

1. Decouple the ManagementApiCore from the ConsumerApi
2. Add customized implementations for all services that previously used the Consumer API
    - These services are implemented in the same way their counterparts from the ConsumerAPI are

## Issues

PR #61

## How to test the changes

The end user shouldn't notice any differences.
