### PR TITLE
🔥 Remove CallActivity notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@process-engine/correlation.contracts": "2.2.0-cf63a55e-b11",
     "@process-engine/cronjob_history.contracts": "1.1.0-b5e4a478-b7",
     "@process-engine/logging_api_contracts": "^1.0.3",
-    "@process-engine/management_api_contracts": "feature~remove_on_call_activity_waiting_notification",
+    "@process-engine/management_api_contracts": "13.0.0-d2eb9786-b32",
     "@process-engine/metrics_api_contracts": "^2.0.0",
     "@process-engine/process_engine_contracts": "46.0.0-13502a51-b24",
     "@process-engine/process_model.contracts": "2.7.0-acad6f21-b10",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@process-engine/correlation.contracts": "2.2.0-cf63a55e-b11",
     "@process-engine/cronjob_history.contracts": "1.1.0-b5e4a478-b7",
     "@process-engine/logging_api_contracts": "^1.0.3",
-    "@process-engine/management_api_contracts": "12.1.0-9485c176-b31",
+    "@process-engine/management_api_contracts": "feature~remove_on_call_activity_waiting_notification",
     "@process-engine/metrics_api_contracts": "^2.0.0",
     "@process-engine/process_engine_contracts": "46.0.0-13502a51-b24",
     "@process-engine/process_model.contracts": "2.7.0-acad6f21-b10",

--- a/src/adapters/notification_adapter.ts
+++ b/src/adapters/notification_adapter.ts
@@ -65,58 +65,6 @@ export class NotificationAdapter {
     return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
   }
 
-  // ------------ For backwards compatibility only
-
-  public async onCallActivityWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-
-    const eventName = Messages.EventAggregatorSettings.messagePaths.activityReached;
-
-    const sanitationCallback = (message: ActivityReachedMessage): void => {
-
-      if (message.flowNodeType !== BpmnType.callActivity) {
-        return;
-      }
-
-      const sanitizedMessage = this.sanitizeMessage<ActivityReachedMessage>(message);
-
-      sanitizedMessage.flowNodeType = message.flowNodeType;
-
-      callback(sanitizedMessage);
-    };
-
-    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
-  }
-
-  public async onCallActivityFinished(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-
-    const eventName = Messages.EventAggregatorSettings.messagePaths.activityFinished;
-
-    const sanitationCallback = (message: ActivityFinishedMessage): void => {
-
-      if (message.flowNodeType !== BpmnType.callActivity) {
-        return;
-      }
-
-      const sanitizedMessage = this.sanitizeMessage<ActivityFinishedMessage>(message);
-
-      sanitizedMessage.flowNodeType = message.flowNodeType;
-
-      callback(sanitizedMessage);
-    };
-
-    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
-  }
-
-  // ------------
-
   public onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,

--- a/src/notification_service.ts
+++ b/src/notification_service.ts
@@ -306,28 +306,4 @@ export class NotificationService implements APIs.INotificationManagementApi {
     return this.notificationAdapter.removeSubscription(subscription);
   }
 
-  // -------------- For backwards compatibility only
-
-  public async onCallActivityWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
-    subscribeOnce?: boolean,
-  ): Promise<Subscription> {
-    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
-
-    return this.notificationAdapter.onCallActivityWaiting(identity, callback, subscribeOnce);
-  }
-
-  public async onCallActivityFinished(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
-    subscribeOnce?: boolean,
-  ): Promise<Subscription> {
-    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
-
-    return this.notificationAdapter.onCallActivityFinished(identity, callback, subscribeOnce);
-  }
-
-  // --------------
-
 }


### PR DESCRIPTION
## Changes

1. Remove all the deprecated `CallActivity` notifications

## Issues

PR: #68