### PR TITLE
✨ Add Queries for retrieving ProcessInstances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_core",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "service implementation for the process-engine.io Management APIs",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   "homepage": "https://github.com/process-engine/management_api_core#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
-    "@process-engine/correlation.contracts": "2.2.0-alpha.1",
+    "@process-engine/correlation.contracts": "feature~flatten_correlation_types",
     "@process-engine/cronjob_history.contracts": "1.1.0-alpha.1",
     "@process-engine/flow_node_instance.contracts": "2.1.0-alpha.1",
     "@process-engine/logging_api_contracts": "^1.0.3",
-    "@process-engine/management_api_contracts": "13.0.0-alpha.1",
+    "@process-engine/management_api_contracts": "feature~flatten_correlation_types",
     "@process-engine/metrics_api_contracts": "^2.0.0",
     "@process-engine/process_engine_contracts": "46.0.0-alpha.1",
     "@process-engine/process_model.contracts": "2.7.0-alpha.1",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   "homepage": "https://github.com/process-engine/management_api_core#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
-    "@process-engine/correlation.contracts": "feature~flatten_correlation_types",
+    "@process-engine/correlation.contracts": "3.0.0-alpha.1",
     "@process-engine/cronjob_history.contracts": "1.1.0-alpha.1",
     "@process-engine/flow_node_instance.contracts": "2.1.0-alpha.1",
     "@process-engine/logging_api_contracts": "^1.0.3",
-    "@process-engine/management_api_contracts": "feature~flatten_correlation_types",
+    "@process-engine/management_api_contracts": "14.0.0-alpha.1",
     "@process-engine/metrics_api_contracts": "^2.0.0",
     "@process-engine/process_engine_contracts": "46.0.0-alpha.1",
     "@process-engine/process_model.contracts": "2.7.0-alpha.1",

--- a/src/converters/empty_activity_converter.ts
+++ b/src/converters/empty_activity_converter.ts
@@ -79,10 +79,9 @@ export class EmptyActivityConverter {
   }
 
   private async getProcessModelHashForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<string> {
-    const correlationForProcessInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
+    const processInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
 
-    // Note that ProcessInstances will only ever have one processModel and therefore only one hash attached to them.
-    return correlationForProcessInstance.processInstances[0].hash;
+    return processInstance.hash;
   }
 
   private async convertSuspendedFlowNodeToEmptyActivity(

--- a/src/converters/event_converter.ts
+++ b/src/converters/event_converter.ts
@@ -84,10 +84,9 @@ export class EventConverter {
   }
 
   private async getProcessModelHashForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<string> {
-    const correlationForProcessInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
+    const processInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
 
-    // Note that ProcessInstances will only ever have one processModel and therefore only one hash attached to them.
-    return correlationForProcessInstance.processInstances[0].hash;
+    return processInstance.hash;
   }
 
   private convertToManagementApiEvent(flowNodeModel: Model.Events.Event, suspendedFlowNode: FlowNodeInstance): DataModels.Events.Event {

--- a/src/converters/manual_task_converter.ts
+++ b/src/converters/manual_task_converter.ts
@@ -79,10 +79,9 @@ export class ManualTaskConverter {
   }
 
   private async getProcessModelHashForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<string> {
-    const correlationForProcessInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
+    const processInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
 
-    // Note that ProcessInstances will only ever have one processModel and therefore only one hash attached to them.
-    return correlationForProcessInstance.processInstances[0].hash;
+    return processInstance.hash;
   }
 
   private async convertSuspendedFlowNodeToManualTask(

--- a/src/converters/user_task_converter.ts
+++ b/src/converters/user_task_converter.ts
@@ -97,10 +97,9 @@ export class UserTaskConverter {
   }
 
   private async getProcessModelHashForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<string> {
-    const correlationForProcessInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
+    const processInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
 
-    // Note that ProcessInstances will only ever have one processModel and therefore only one hash attached to them.
-    return correlationForProcessInstance.processInstances[0].hash;
+    return processInstance.hash;
   }
 
   private async convertToManagementApiUserTask(

--- a/src/correlation_service.ts
+++ b/src/correlation_service.ts
@@ -21,7 +21,7 @@ export class CorrelationService implements APIs.ICorrelationManagementApi {
 
     const correlations = await this.correlationService.getAll(identity);
 
-    const managementApiCorrelations = correlations.map(this.mapToPublicCorrelation);
+    const managementApiCorrelations = correlations.map<DataModels.Correlations.Correlation>(this.mapToPublicCorrelation.bind(this));
 
     const paginizedCorrelations = applyPagination(managementApiCorrelations, offset, limit);
 
@@ -36,7 +36,7 @@ export class CorrelationService implements APIs.ICorrelationManagementApi {
 
     const activeCorrelations = await this.correlationService.getActive(identity);
 
-    const managementApiCorrelations = activeCorrelations.map(this.mapToPublicCorrelation);
+    const managementApiCorrelations = activeCorrelations.map<DataModels.Correlations.Correlation>(this.mapToPublicCorrelation.bind(this));
 
     const paginizedCorrelations = applyPagination(managementApiCorrelations, offset, limit);
 
@@ -61,7 +61,7 @@ export class CorrelationService implements APIs.ICorrelationManagementApi {
 
     const correlations = await this.correlationService.getByProcessModelId(identity, processModelId);
 
-    const managementApiCorrelations = correlations.map(this.mapToPublicCorrelation);
+    const managementApiCorrelations = correlations.map<DataModels.Correlations.Correlation>(this.mapToPublicCorrelation.bind(this));
 
     const paginizedCorrelations = applyPagination(managementApiCorrelations, offset, limit);
 


### PR DESCRIPTION
## Changes

1. Update the converters with the new correlation contracts
2. Rename `getCorrelationByProcessInstanceId` to `getProcessInstanceById`
3. Add UseCases for getting ProcessInstances:
    - getProcessInstancesForCorrelation
    - getProcessInstancesForProcessModel
    - getProcessInstancesByState

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/404

PR: #69