### PR TITLE
⚡️ ✨ Add lane and name to flow node instance

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -34,13 +34,10 @@ function registerInContainer(container) {
   container
     .register('ManagementApiEmptyActivityService', EmptyActivityService)
     .dependencies(
-      'CorrelationService',
       'EventAggregator',
       'FlowNodeInstanceService',
       'IamService',
       'ManagementApiNotificationAdapter',
-      'ProcessModelFacadeFactory',
-      'ProcessModelUseCases',
     )
     .singleton();
 
@@ -79,13 +76,10 @@ function registerInContainer(container) {
   container
     .register('ManagementApiManualTaskService', ManualTaskService)
     .dependencies(
-      'CorrelationService',
       'EventAggregator',
       'FlowNodeInstanceService',
       'IamService',
       'ManagementApiNotificationAdapter',
-      'ProcessModelFacadeFactory',
-      'ProcessModelUseCases',
     )
     .singleton();
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@process-engine/logging_api_contracts": "^1.0.3",
     "@process-engine/management_api_contracts": "^13.0.0",
     "@process-engine/metrics_api_contracts": "^2.0.0",
-    "@process-engine/persistence_api.contracts": "1.1.0-alpha.2",
+    "@process-engine/persistence_api.contracts": "feature~add_lane_and_name_to_flow_node_instance",
     "@process-engine/process_engine_contracts": "^46.0.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@process-engine/logging_api_contracts": "^1.0.3",
     "@process-engine/management_api_contracts": "^13.0.0",
     "@process-engine/metrics_api_contracts": "^2.0.0",
-    "@process-engine/persistence_api.contracts": "feature~add_lane_and_name_to_flow_node_instance",
+    "@process-engine/persistence_api.contracts": "1.1.0-alpha.3",
     "@process-engine/process_engine_contracts": "^46.0.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",

--- a/src/empty_activity_service.ts
+++ b/src/empty_activity_service.ts
@@ -7,52 +7,35 @@ import {
   BpmnType,
   FlowNodeInstance,
   FlowNodeInstanceState,
-  ICorrelationService,
   IFlowNodeInstanceService,
-  IProcessModelUseCases,
-  Model,
   ProcessTokenType,
 } from '@process-engine/persistence_api.contracts';
-import {
-  IProcessModelFacade,
-  IProcessModelFacadeFactory,
-  FinishEmptyActivityMessage as InternalFinishEmptyActivityMessage,
-} from '@process-engine/process_engine_contracts';
+import {FinishEmptyActivityMessage as InternalFinishEmptyActivityMessage} from '@process-engine/process_engine_contracts';
 
 import {NotificationAdapter} from './adapters/index';
 import {applyPagination} from './paginator';
 
-import * as ProcessModelCache from './process_model_cache';
+const superAdminClaim = 'can_manage_process_instances';
+const canSubscribeToEventsClaim = 'can_subscribe_to_events';
 
 export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
 
-  private readonly correlationService: ICorrelationService;
   private readonly eventAggregator: IEventAggregator;
   private readonly flowNodeInstanceService: IFlowNodeInstanceService;
   private readonly iamService: IIAMService;
-  private readonly processModelUseCase: IProcessModelUseCases;
-  private readonly processModelFacadeFactory: IProcessModelFacadeFactory;
 
   private readonly notificationAdapter: NotificationAdapter;
 
-  private readonly canSubscribeToEventsClaim = 'can_subscribe_to_events';
-
   constructor(
-    correlationService: ICorrelationService,
     eventAggregator: IEventAggregator,
     flowNodeInstanceService: IFlowNodeInstanceService,
     iamService: IIAMService,
     notificationAdapter: NotificationAdapter,
-    processModelFacadeFactory: IProcessModelFacadeFactory,
-    processModelUseCase: IProcessModelUseCases,
   ) {
-    this.correlationService = correlationService;
     this.eventAggregator = eventAggregator;
     this.flowNodeInstanceService = flowNodeInstanceService;
     this.iamService = iamService;
     this.notificationAdapter = notificationAdapter;
-    this.processModelFacadeFactory = processModelFacadeFactory;
-    this.processModelUseCase = processModelUseCase;
   }
 
   public async onEmptyActivityWaiting(
@@ -60,7 +43,7 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+    await this.ensureHasClaim(identity, canSubscribeToEventsClaim);
 
     return this.notificationAdapter.onEmptyActivityWaiting(identity, callback, subscribeOnce);
   }
@@ -70,7 +53,7 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
     callback: Messages.CallbackTypes.OnEmptyActivityFinishedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+    await this.ensureHasClaim(identity, canSubscribeToEventsClaim);
 
     return this.notificationAdapter.onEmptyActivityFinished(identity, callback, subscribeOnce);
   }
@@ -80,7 +63,7 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+    await this.ensureHasClaim(identity, canSubscribeToEventsClaim);
 
     return this.notificationAdapter.onEmptyActivityForIdentityWaiting(identity, callback, subscribeOnce);
   }
@@ -90,7 +73,7 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
     callback: Messages.CallbackTypes.OnEmptyActivityFinishedCallback,
     subscribeOnce?: boolean,
   ): Promise<Subscription> {
-    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+    await this.ensureHasClaim(identity, canSubscribeToEventsClaim);
 
     return this.notificationAdapter.onEmptyActivityForIdentityFinished(identity, callback, subscribeOnce);
   }
@@ -104,11 +87,7 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
 
     const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByProcessModel(processModelId);
 
-    const emptyActivities = suspendedFlowNodes.filter(this.checkIfIsFlowNodeIsEmptyActivity);
-
-    const emptyActivityList = await this.convertFlowNodeInstancesToEmptyActivities(identity, emptyActivities);
-
-    emptyActivityList.emptyActivities = applyPagination(emptyActivityList.emptyActivities, offset, limit);
+    const emptyActivityList = await this.filterAndConvertEmptyActivityList(identity, suspendedFlowNodes, offset, limit);
 
     return emptyActivityList;
   }
@@ -122,11 +101,7 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
 
     const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByProcessInstance(processInstanceId);
 
-    const emptyActivities = suspendedFlowNodes.filter(this.checkIfIsFlowNodeIsEmptyActivity);
-
-    const emptyActivityList = await this.convertFlowNodeInstancesToEmptyActivities(identity, emptyActivities);
-
-    emptyActivityList.emptyActivities = applyPagination(emptyActivityList.emptyActivities, offset, limit);
+    const emptyActivityList = await this.filterAndConvertEmptyActivityList(identity, suspendedFlowNodes, offset, limit);
 
     return emptyActivityList;
   }
@@ -140,11 +115,7 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
 
     const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByCorrelation(correlationId);
 
-    const emptyActivities = suspendedFlowNodes.filter(this.checkIfIsFlowNodeIsEmptyActivity);
-
-    const emptyActivityList = await this.convertFlowNodeInstancesToEmptyActivities(identity, emptyActivities);
-
-    emptyActivityList.emptyActivities = applyPagination(emptyActivityList.emptyActivities, offset, limit);
+    const emptyActivityList = await this.filterAndConvertEmptyActivityList(identity, suspendedFlowNodes, offset, limit);
 
     return emptyActivityList;
   }
@@ -157,17 +128,13 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
     limit: number = 0,
   ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
 
-    const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByCorrelation(correlationId);
+    const flowNodeInstances = await this.flowNodeInstanceService.queryByCorrelationAndProcessModel(correlationId, processModelId);
 
-    const suspendedProcessModelFlowNodes = suspendedFlowNodes.filter((flowNodeInstance: FlowNodeInstance): boolean => {
-      const isEmptyActivity = this.checkIfIsFlowNodeIsEmptyActivity(flowNodeInstance);
-      const belongsToProcessModel = flowNodeInstance.processModelId === processModelId;
-      return isEmptyActivity && belongsToProcessModel;
+    const suspendedFlowNodes = flowNodeInstances.filter((flowNodeInstance: FlowNodeInstance): boolean => {
+      return flowNodeInstance.state === FlowNodeInstanceState.suspended;
     });
 
-    const emptyActivityList = await this.convertFlowNodeInstancesToEmptyActivities(identity, suspendedProcessModelFlowNodes);
-
-    emptyActivityList.emptyActivities = applyPagination(emptyActivityList.emptyActivities, offset, limit);
+    const emptyActivityList = await this.filterAndConvertEmptyActivityList(identity, suspendedFlowNodes, offset, limit);
 
     return emptyActivityList;
   }
@@ -186,9 +153,9 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
       return isEmptyActivity && userIdsMatch;
     });
 
-    const emptyActivityList = await this.convertFlowNodeInstancesToEmptyActivities(identity, flowNodeInstancesOwnedByUser);
+    const emptyActivitiesToReturn = applyPagination(flowNodeInstancesOwnedByUser, offset, limit);
 
-    emptyActivityList.emptyActivities = applyPagination(emptyActivityList.emptyActivities, offset, limit);
+    const emptyActivityList = this.convertFlowNodeInstancesToEmptyActivities(emptyActivitiesToReturn);
 
     return emptyActivityList;
   }
@@ -210,9 +177,9 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
       throw new EssentialProjectErrors.NotFoundError(errorMessage);
     }
 
-    const convertedEmptyActivityList = await this.convertFlowNodeInstancesToEmptyActivities(identity, [matchingFlowNodeInstance]);
-
-    const matchingEmptyActivity = convertedEmptyActivityList.emptyActivities[0];
+    if (matchingFlowNodeInstance.flowNodeLane !== undefined) {
+      await this.ensureHasClaim(identity, matchingFlowNodeInstance.flowNodeLane);
+    }
 
     return new Promise<void>((resolve: Function): void => {
       const routePrameter: {[name: string]: string} = Messages.EventAggregatorSettings.messageParams;
@@ -227,19 +194,31 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
         resolve();
       });
 
-      this.publishFinishEmptyActivityEvent(identity, matchingEmptyActivity);
+      this.publishFinishEmptyActivityEvent(identity, matchingFlowNodeInstance);
     });
   }
 
-  public async convertFlowNodeInstancesToEmptyActivities(
+  public async filterAndConvertEmptyActivityList(
     identity: IIdentity,
     suspendedFlowNodes: Array<FlowNodeInstance>,
+    offset?: number,
+    limit?: number,
   ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
 
-    const suspendedEmptyActivities =
-      await Promise.map(suspendedFlowNodes, async (suspendedFlowNode): Promise<DataModels.EmptyActivities.EmptyActivity> => {
-        return this.convertSuspendedFlowNodeToEmptyActivity(identity, suspendedFlowNode);
-      });
+    const emptyActivities = suspendedFlowNodes.filter(this.checkIfIsFlowNodeIsEmptyActivity);
+
+    const accessibleEmptyActivities = await this.filterInacessibleFlowNodeInstances(identity, emptyActivities);
+
+    const emptyActivitiesToReturn = applyPagination(accessibleEmptyActivities, offset, limit);
+
+    const emptyActivityList = this.convertFlowNodeInstancesToEmptyActivities(emptyActivitiesToReturn);
+
+    return emptyActivityList;
+  }
+
+  private convertFlowNodeInstancesToEmptyActivities(suspendedFlowNodes: Array<FlowNodeInstance>): DataModels.EmptyActivities.EmptyActivityList {
+
+    const suspendedEmptyActivities = suspendedFlowNodes.map(this.convertSuspendedFlowNodeToEmptyActivity);
 
     const emptyActivityList: DataModels.EmptyActivities.EmptyActivityList = {
       emptyActivities: suspendedEmptyActivities,
@@ -257,59 +236,73 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
     return identityA.userId === identityB.userId;
   }
 
-  private async convertSuspendedFlowNodeToEmptyActivity(
+  private async filterInacessibleFlowNodeInstances(
     identity: IIdentity,
-    emptyActivityInstance: FlowNodeInstance,
-  ): Promise<DataModels.EmptyActivities.EmptyActivity> {
+    flowNodeInstances: Array<FlowNodeInstance>,
+  ): Promise<Array<FlowNodeInstance>> {
+    const isSuperAdmin = await this.checkIfUserIsSuperAdmin(identity);
+
+    if (isSuperAdmin) {
+      return flowNodeInstances;
+    }
+
+    const accessibleFlowNodeInstances = Promise.filter(flowNodeInstances, async (item: FlowNodeInstance): Promise<boolean> => {
+      return this.checkIfUserCanAccessFlowNodeInstance(identity, item);
+    });
+
+    return accessibleFlowNodeInstances;
+  }
+
+  private async checkIfUserCanAccessFlowNodeInstance(identity: IIdentity, flowNodeInstance: FlowNodeInstance): Promise<boolean> {
+    try {
+      if (!flowNodeInstance.flowNodeLane) {
+        return true;
+      }
+
+      await this.iamService.ensureHasClaim(identity, flowNodeInstance.flowNodeLane);
+
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  private async ensureHasClaim(identity: IIdentity, claimName: string): Promise<void> {
+    const isSuperAdmin = await this.checkIfUserIsSuperAdmin(identity);
+
+    if (isSuperAdmin) {
+      return;
+    }
+
+    await this.iamService.ensureHasClaim(identity, claimName);
+  }
+
+  private async checkIfUserIsSuperAdmin(identity: IIdentity): Promise<boolean> {
+    try {
+      await this.iamService.ensureHasClaim(identity, superAdminClaim);
+
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  private convertSuspendedFlowNodeToEmptyActivity(emptyActivityInstance: FlowNodeInstance): DataModels.EmptyActivities.EmptyActivity {
 
     const onSuspendToken = emptyActivityInstance.getTokenByType(ProcessTokenType.onSuspend);
 
-    const processModelFacade = await this.getProcessModelForFlowNodeInstance(identity, emptyActivityInstance);
-    const emptyActivityModel = processModelFacade.getFlowNodeById(emptyActivityInstance.flowNodeId);
-
-    const consumerApiEmptyActivity: DataModels.EmptyActivities.EmptyActivity = {
+    const managementApiEmptyActivity: DataModels.EmptyActivities.EmptyActivity = {
       flowNodeType: BpmnType.emptyActivity,
       id: emptyActivityInstance.flowNodeId,
       flowNodeInstanceId: emptyActivityInstance.id,
-      name: emptyActivityModel.name,
+      name: emptyActivityInstance.flowNodeName,
       correlationId: emptyActivityInstance.correlationId,
       processModelId: emptyActivityInstance.processModelId,
       processInstanceId: emptyActivityInstance.processInstanceId,
       tokenPayload: onSuspendToken.payload,
     };
 
-    return consumerApiEmptyActivity;
-  }
-
-  private async getProcessModelForFlowNodeInstance(
-    identity: IIdentity,
-    flowNodeInstance: FlowNodeInstance,
-  ): Promise<IProcessModelFacade> {
-
-    let processModel: Model.Process;
-
-    // We must store the ProcessModel for each user, to account for lane-restrictions.
-    // Some users may not be able to see some lanes that are visible to others.
-    const cacheKeyToUse = `${flowNodeInstance.processInstanceId}-${identity.userId}`;
-
-    const cacheHasMatchingEntry = ProcessModelCache.hasEntry(cacheKeyToUse);
-    if (cacheHasMatchingEntry) {
-      processModel = ProcessModelCache.get(cacheKeyToUse);
-    } else {
-      const processModelHash = await this.getProcessModelHashForProcessInstance(identity, flowNodeInstance.processInstanceId);
-      processModel = await this.processModelUseCase.getByHash(identity, flowNodeInstance.processModelId, processModelHash);
-      ProcessModelCache.add(cacheKeyToUse, processModel);
-    }
-
-    const processModelFacade = this.processModelFacadeFactory.create(processModel);
-
-    return processModelFacade;
-  }
-
-  private async getProcessModelHashForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<string> {
-    const processInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
-
-    return processInstance.hash;
+    return managementApiEmptyActivity;
   }
 
   private async getFlowNodeInstanceForCorrelationInProcessInstance(
@@ -330,23 +323,25 @@ export class EmptyActivityService implements APIs.IEmptyActivityManagementApi {
 
   private publishFinishEmptyActivityEvent(
     identity: IIdentity,
-    emptyActivityInstance: DataModels.EmptyActivities.EmptyActivity,
+    emptyActivityInstance: FlowNodeInstance,
   ): void {
+
+    const currentToken = emptyActivityInstance.getTokenByType(ProcessTokenType.onSuspend);
 
     const finishEmptyActivityMessage = new InternalFinishEmptyActivityMessage(
       emptyActivityInstance.correlationId,
       emptyActivityInstance.processModelId,
       emptyActivityInstance.processInstanceId,
       emptyActivityInstance.id,
-      emptyActivityInstance.flowNodeInstanceId,
+      emptyActivityInstance.id,
       identity,
-      emptyActivityInstance.tokenPayload,
+      currentToken.payload,
     );
 
     const finishEmptyActivityEvent = Messages.EventAggregatorSettings.messagePaths.finishEmptyActivity
       .replace(Messages.EventAggregatorSettings.messageParams.correlationId, emptyActivityInstance.correlationId)
       .replace(Messages.EventAggregatorSettings.messageParams.processInstanceId, emptyActivityInstance.processInstanceId)
-      .replace(Messages.EventAggregatorSettings.messageParams.flowNodeInstanceId, emptyActivityInstance.flowNodeInstanceId);
+      .replace(Messages.EventAggregatorSettings.messageParams.flowNodeInstanceId, emptyActivityInstance.id);
 
     this.eventAggregator.publish(finishEmptyActivityEvent, finishEmptyActivityMessage);
   }

--- a/src/flow_node_instance_service.ts
+++ b/src/flow_node_instance_service.ts
@@ -154,15 +154,14 @@ export class FlowNodeInstanceService implements APIs.IFlowNodeInstanceManagement
     return {flowNodeInstances: paginizedFlowNodeInstances, totalCount: flowNodeInstances.length};
   }
 
-  private async convertFlowNodeInstancesToTaskList(identity: IIdentity, suspendedFlowNodes: Array<FlowNodeInstance>): Promise<Array<Task>> {
+  private async convertFlowNodeInstancesToTaskList(
+    identity: IIdentity,
+    suspendedFlowNodes: Array<FlowNodeInstance>,
+  ): Promise<Array<Task>> {
 
-    const suspendedEmptyActivities = suspendedFlowNodes.filter((flowNode): boolean => flowNode.flowNodeType === BpmnType.emptyActivity);
-    const suspendedManualTasks = suspendedFlowNodes.filter((flowNode): boolean => flowNode.flowNodeType === BpmnType.manualTask);
-    const suspendedUserTasks = suspendedFlowNodes.filter((flowNode): boolean => flowNode.flowNodeType === BpmnType.userTask);
-
-    const emptyActivityList = await this.emptyActivityService.convertFlowNodeInstancesToEmptyActivities(identity, suspendedEmptyActivities);
-    const manualTaskList = await this.manualTaskService.convertFlowNodeInstancesToManualTasks(identity, suspendedManualTasks);
-    const userTaskList = await this.userTaskService.convertFlowNodeInstancesToUserTasks(identity, suspendedUserTasks);
+    const emptyActivityList = await this.emptyActivityService.filterAndConvertEmptyActivityList(identity, suspendedFlowNodes);
+    const manualTaskList = await this.manualTaskService.filterAndConvertManualTaskList(identity, suspendedFlowNodes);
+    const userTaskList = await this.userTaskService.filterAndConvertUserTaskList(identity, suspendedFlowNodes);
 
     const tasks = [...emptyActivityList.emptyActivities, ...manualTaskList.manualTasks, ...userTaskList.userTasks];
 


### PR DESCRIPTION
## Changes

1. Use the value of `FlowNodeInstance.flowNodeLane` to perform claim checks for task accessibility 
    - Includes UserTasks, ManualTasks, Events and EmptyActivities
2. Perform task filtering and pagination prior to conversion
3. Remove retrieval of a tasks's ProcessModel from the ManualTaskService and EmptyActivityService
    - This was not entirely possible for the other services, because Events and UserTasks require a lot of information from their models that cannot be added to a FlowNodeInstance (the UserTask's FormField Configs, for example)
    - The services will benefit from increased performance, because they now only have to perform a fraction of the `getProcessModel` queries they did before
4. Account for `SuperAdmin` claim during all queries, which greatly reduces the number of claim checks performed, if the requesting user actually is a super admin
5. When a user is not allowed to see any suspended task, he will now receive an empty array, instead of a 403. 
    - This fixes a possible issue, where a user might get more information about existing tasks, than he is supposed to 
    - i.e.: 403 says "there is something there, I just can't see it"; an empty Array suggests "there is nothing there to see"

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/427

PR: #73

## How to test the changes

- Run various requests for retrieving ManualTasks, UserTasks, Events and/or EmptyActivities
- The more tasks you retrieve, the greater the performance boost you should be able to notice