### PR TITLE
🔒 Use correct identity for terminating ProcessInstances manually

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ pipeline {
       }
     }
     stage('Install dependencies') {
+      options {skipDefaultCheckout()}
       when {
         expression {buildIsRequired == true}
       }
@@ -62,6 +63,7 @@ pipeline {
       }
     }
     stage('Build Sources') {
+      options {skipDefaultCheckout()}
       when {
         expression {buildIsRequired == true}
       }
@@ -71,6 +73,7 @@ pipeline {
       }
     }
     stage('Test') {
+      options {skipDefaultCheckout()}
       when {
         expression {buildIsRequired == true}
       }
@@ -90,6 +93,7 @@ pipeline {
       }
     }
     stage('Set package version') {
+      options {skipDefaultCheckout()}
       when {
         expression {buildIsRequired == true}
       }
@@ -99,6 +103,7 @@ pipeline {
       }
     }
     stage('Publish') {
+      options {skipDefaultCheckout()}
       when {
         expression {buildIsRequired == true}
       }
@@ -130,6 +135,7 @@ pipeline {
       }
     }
     stage('Cleanup') {
+      options {skipDefaultCheckout()}
       when {
         expression {buildIsRequired == true}
       }

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -91,6 +91,7 @@ function registerInContainer(container) {
   container
     .register('ManagementApiProcessModelService', ProcessModelService)
     .dependencies(
+      'CorrelationService',
       'CronjobService',
       'EventAggregator',
       'ExecuteProcessService',

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@process-engine/logging_api_contracts": "^2.0.0",
     "@process-engine/management_api_contracts": "^13.1.0",
     "@process-engine/persistence_api.contracts": "^1.1.0",
-    "@process-engine/process_engine_contracts": "^46.0.0",
+    "@process-engine/process_engine_contracts": "feature~add_identity_to_terminate_process_command",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",
     "clone": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_core",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "service implementation for the process-engine.io Management APIs",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@process-engine/logging_api_contracts": "^2.0.0",
     "@process-engine/management_api_contracts": "^13.1.0",
     "@process-engine/persistence_api.contracts": "^1.1.0",
-    "@process-engine/process_engine_contracts": "feature~add_identity_to_terminate_process_command",
+    "@process-engine/process_engine_contracts": "46.1.0-alpha.2",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",
     "clone": "^2.1.2",

--- a/src/process_model_service.ts
+++ b/src/process_model_service.ts
@@ -161,7 +161,11 @@ export class ProcessModelService implements APIs.IProcessModelManagementApi {
     const terminateEvent = Messages.EventAggregatorSettings.messagePaths.terminateProcessInstance
       .replace(Messages.EventAggregatorSettings.messageParams.processInstanceId, processInstanceId);
 
-    this.eventAggregator.publish(terminateEvent);
+    const eventPayload = {
+      terminatedBy: identity,
+    };
+
+    this.eventAggregator.publish(terminateEvent, eventPayload);
   }
 
   // Notifications


### PR DESCRIPTION
## Changes

1. Add a users identity to the payload send with the `terminateProcessInstance` event
2. Query a ProcessInstance with the requesting users identity, prior to terminating the ProcessInstance
    - This is meant to ensure that the user is allowed to access the ProcessInstance
    - If the ProcessInstance does not exists, or the user cannot access it, a 404 is thrown

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/474

PR: #75

## How to test the changes

- Start a ProcessInstance
- Use `terminateProcessInstance` to terminate it
- See that all claim checks are performed against the identity that made the termination request