### PR TITLE
✨ Add terminatedBy and finishedAt to ProcessInstances

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
     "@process-engine/logging_api_contracts": "^2.0.0",
-    "@process-engine/management_api_contracts": "^13.1.0",
-    "@process-engine/persistence_api.contracts": "^1.1.0",
+    "@process-engine/management_api_contracts": "feature~add_terminated_by_field",
+    "@process-engine/persistence_api.contracts": "feature~add_terminated_by_field",
     "@process-engine/process_engine_contracts": "46.1.0-alpha.2",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
     "@process-engine/logging_api_contracts": "^2.0.0",
-    "@process-engine/management_api_contracts": "feature~add_terminated_by_field",
-    "@process-engine/persistence_api.contracts": "feature~add_terminated_by_field",
+    "@process-engine/management_api_contracts": "13.2.0-alpha.1",
+    "@process-engine/persistence_api.contracts": "1.3.0-alpha.2",
     "@process-engine/process_engine_contracts": "46.1.0-alpha.2",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",

--- a/src/correlation_service.ts
+++ b/src/correlation_service.ts
@@ -155,6 +155,8 @@ export class CorrelationService implements APIs.ICorrelationManagementApi {
     managementApiProcessInstance.error = runtimeProcessInstance.error;
     managementApiProcessInstance.identity = runtimeProcessInstance.identity;
     managementApiProcessInstance.createdAt = runtimeProcessInstance.createdAt;
+    managementApiProcessInstance.terminatedBy = runtimeProcessInstance.terminatedBy;
+    managementApiProcessInstance.finishedAt = runtimeProcessInstance.finishedAt;
 
     return managementApiProcessInstance;
   }


### PR DESCRIPTION
## Changes

1. Add optional `terminatedBy` and `finishedAt` columns to Processinstance model

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/478

PR: #76

## How to test the changes

- Run a few ProcessInstances and terminate them through a TerminateEndEvent or manually
- Query those ProcessInstances through the Management API
- Note that the ProcessInstances that terminated through a TerminateEndEvent will not have a value for `terminatedBy`
- Note that the ProcessInstances you terminated manually _will_ have such an identity